### PR TITLE
✅ Add ReDos check test

### DIFF
--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -270,6 +270,11 @@ class TestParseOptionsHeader(unittest.TestCase):
         t, p = parse_options_header(b'text/plain; filename="C:\\this\\is\\a\\path\\file.txt"')
 
         self.assertEqual(p[b'filename'], b'file.txt')
+    
+    def test_redos_attack_header(self):
+        t, p = parse_options_header(b'application/x-www-form-urlencoded; !="\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\')
+        # If vulnerable, this test wouldn't finish, the line above would hang
+        self.assertIn(b'"\\', p[b'!'])
 
 
 class TestBaseParser(unittest.TestCase):


### PR DESCRIPTION
✅ Add ReDos check test

Tests that a vulnerability like Starlette's https://github.com/encode/starlette/security/advisories/GHSA-93gm-qmq6-w238 and FastAPI's https://github.com/tiangolo/fastapi/security/advisories/GHSA-qf9m-vfgh-m389, that were really vulnerabilities in python-multipart, don't happen again.