### PR TITLE
BaseParser should receive the `callbacks` dict

### DIFF
--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -290,8 +290,8 @@ class TestParseOptionsHeader(unittest.TestCase):
 
 class TestBaseParser(unittest.TestCase):
     def setUp(self):
-        self.b = BaseParser()
-        self.b.callbacks = {}
+        callbacks = {}
+        self.b = BaseParser(callbacks)
 
     def test_callbacks(self):
         called = 0


### PR DESCRIPTION
There are a couple things that I'd like to get feedback on:
1. `Mapping` is compatible with derived `TypedDict`, but `MutableMapping`, is not.
2. Only MutableMapping has `__setitem__` and `__delitem__` (used in `BaseParser.set_callback`).
3. Using `TypedDict` can be misleading for users. For example:
```python
from multipart.multipart import OctetStreamParser, OctetStreamCallbacks

def foo():
    return None

def bar(b: bytes, x: int, y: int):
    print(b, x, y)
    return None

# [OK] Explicit
explicit = OctetStreamParser(callbacks={"on_start": foo, "on_data": bar, "on_end": foo})
# =======

# [OK] From hinted variable
a: OctetStreamCallbacks = {"on_start": foo, "on_data": bar, "on_end": foo}
from_hinted_variable = OctetStreamParser(callbacks=a)
# =======

# [WARNING] From non-hinted variable
b = {"on_start": foo, "on_data": bar, "on_end": foo}
from_non_hinted_variable = OctetStreamParser(callbacks=b) # <---- WARNING HERE
# Diagnostics:
# 1. Argument of type "dict[str, Unknown]" cannot be assigned to parameter "callbacks" of type "OctetStreamCallbacks" in function "__init__"
#      "dict[str, Unknown]" is incompatible with "OctetStreamCallbacks" [reportArgumentType]
```
Users will get a warning even if they're doing things right because of a missing type hint!

How much should we play around TypedDict?