### PR TITLE
explicit register slow_test pytest mark to get rid of pytest warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,11 @@ packages = ["multipart"]
 [tool.hatch.build.targets.sdist]
 include = ["/multipart", "/tests"]
 
+[tool.pytest.ini_options]
+markers = [
+    "slow_test: marks tests as slow (deselect with '-m \"not slow_test\"')",
+]
+
 [tool.ruff]
 line-length = 120
 

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -32,29 +32,6 @@ def ensure_in_path(path):
     sys.path.insert(0, path)
 
 
-# Check if pytest is imported.  If so, we use it to create marking decorators.
-# If not, we just create a function that does nothing.
-try:
-    import pytest
-except ImportError:
-    pytest = None
-
-if pytest is not None:
-    slow_test = pytest.mark.slow_test
-    xfail = pytest.mark.xfail
-
-else:
-
-    def slow_test(x):
-        return x
-
-    def xfail(*args, **kwargs):
-        if len(args) > 0 and isinstance(args[0], types.FunctionType):
-            return args[0]
-
-        return lambda x: x
-
-
 # We don't use the pytest parametrizing function, since it seems to break
 # with unittest.TestCase subclasses.
 def parametrize(field_names, field_values):

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import yaml
+from pytest import mark
 
 from multipart.decoders import Base64Decoder, QuotedPrintableDecoder
 from multipart.exceptions import DecodeError, FileError, FormParserError, MultipartParseError
@@ -27,7 +28,7 @@ from multipart.multipart import (
     parse_options_header,
 )
 
-from .compat import parametrize, parametrize_class, slow_test
+from .compat import parametrize, parametrize_class
 
 if TYPE_CHECKING:
     from multipart.multipart import FileConfig
@@ -905,7 +906,7 @@ class TestFormParser(unittest.TestCase):
                 # Assert that our field is here.
                 self.assert_field(b"field", b"0123456789ABCDEFGHIJ0123456789ABCDEFGHIJ")
 
-    @slow_test
+    @mark.slow_test
     def test_request_body_fuzz(self):
         """
         This test randomly fuzzes the request body to ensure that no strange
@@ -978,7 +979,7 @@ class TestFormParser(unittest.TestCase):
         print("Failures:   %d" % (failures,))
         print("Exceptions: %d" % (exceptions,))
 
-    @slow_test
+    @mark.slow_test
     def test_request_body_fuzz_random_data(self):
         """
         This test will fuzz the multipart parser with some number of iterations


### PR DESCRIPTION
Get rid of the warning emitted by pytest due to slow_test not being a registered mark.