### PR TITLE
Minor spelling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-`python-multipart` is an Apache2 licensed streaming multipart parser for Python.
+`python-multipart` is an Apache2-licensed streaming multipart parser for Python.
 Test coverage is currently 100%.
 
 ## Why?


### PR DESCRIPTION
An adjectivised noun used as a specification adverb to a participle must be connected with a hyphen.