### PR TITLE
ensure our boundary matches: improve the message

### DIFF
--- a/multipart/multipart.py
+++ b/multipart/multipart.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+Update multipart.pyfrom __future__ import annotations
 
 import logging
 import os
@@ -1149,7 +1149,9 @@ class MultipartParser(BaseParser):
 
                 else:
                     # Check to ensure our boundary matches
-                    if c != (e := boundary[i2 :=  index + 2]):
+                    i2 =  index + 2
+                    e = boundary[i2]
+                    if c != e:
                         msg = "Expected boundary character %r, got %r at index %d" % (e, c, i2)
                         self.logger.warning(msg)
                         e = MultipartParseError(msg)

--- a/multipart/multipart.py
+++ b/multipart/multipart.py
@@ -1,4 +1,4 @@
-Update multipart.pyfrom __future__ import annotations
+from __future__ import annotations
 
 import logging
 import os

--- a/multipart/multipart.py
+++ b/multipart/multipart.py
@@ -1149,7 +1149,7 @@ class MultipartParser(BaseParser):
 
                 else:
                     # Check to ensure our boundary matches
-                    if c != (e = boundary[i2 =  index + 2]):
+                    if c != (e := boundary[i2 :=  index + 2]):
                         msg = "Expected boundary character %r, got %r at index %d" % (e, c, i2)
                         self.logger.warning(msg)
                         e = MultipartParseError(msg)

--- a/multipart/multipart.py
+++ b/multipart/multipart.py
@@ -1149,8 +1149,9 @@ class MultipartParser(BaseParser):
 
                 else:
                     # Check to ensure our boundary matches
-                    if c != boundary[index + 2]:
-                        msg = "Did not find boundary character %r at index " "%d" % (c, index + 2)
+                    e = boundary[i2 =  index + 2]
+                    if c != e:
+                        msg = "Expected boundary character %r, got %r at index %d" % (e, c, i2)
                         self.logger.warning(msg)
                         e = MultipartParseError(msg)
                         e.offset = i

--- a/multipart/multipart.py
+++ b/multipart/multipart.py
@@ -1149,8 +1149,7 @@ class MultipartParser(BaseParser):
 
                 else:
                     # Check to ensure our boundary matches
-                    e = boundary[i2 =  index + 2]
-                    if c != e:
+                    if c != (e = boundary[i2 =  index + 2]):
                         msg = "Expected boundary character %r, got %r at index %d" % (e, c, i2)
                         self.logger.warning(msg)
                         e = MultipartParseError(msg)

--- a/multipart/multipart.py
+++ b/multipart/multipart.py
@@ -1149,10 +1149,8 @@ class MultipartParser(BaseParser):
 
                 else:
                     # Check to ensure our boundary matches
-                    i2 =  index + 2
-                    e = boundary[i2]
-                    if c != e:
-                        msg = "Expected boundary character %r, got %r at index %d" % (e, c, i2)
+                    if c != boundary[index + 2]:
+                        msg = "Expected boundary character %r, got %r at index %d" % (boundary[index + 2], c, index + 2)
                         self.logger.warning(msg)
                         e = MultipartParseError(msg)
                         e.offset = i

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1057,7 +1057,12 @@ class TestFormParser(unittest.TestCase):
         self.make("boundary")
         data = b"--boundaryfoobar"
         with self.assertRaises(MultipartParseError):
-            i = self.f.write(data)
+            self.f.write(data)
+
+        self.make("boundary")
+        data = b"--Boundary\r\nfoobar"
+        with self.assertRaisesRegex(MultipartParseError, "Expected %r, got %r" % (b"b"[0], b"B"[0])):
+            self.f.write(data)
 
     def test_octet_stream(self) -> None:
         files: list[File] = []

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1061,7 +1061,7 @@ class TestFormParser(unittest.TestCase):
 
         self.make("boundary")
         data = b"--Boundary\r\nfoobar"
-        with self.assertRaisesRegex(MultipartParseError, "Expected %r, got %r" % (b"b"[0], b"B"[0])):
+        with self.assertRaisesRegex(MultipartParseError, "Expected boundary character %r, got %r" % (b"b"[0], b"B"[0])):
             self.f.write(data)
 
     def test_octet_stream(self) -> None:


### PR DESCRIPTION
The error message should report expected actual mismatch.


Edited by @Kludex:
- Closes #123