### PR TITLE
If the input stream is a text stream, use its binary buffer

### DIFF
--- a/multipart/multipart.py
+++ b/multipart/multipart.py
@@ -1937,6 +1937,10 @@ def parse_form(
         content_length = float("inf")
     bytes_read = 0
 
+    # If the input stream is a text stream, use its binary buffer
+    if isinstance (input_stream, type (sys. stdin)):
+        input_stream = input_stream .buffer
+
     while True:
         # Read only up to the Content-Length given.
         max_readable = min(content_length - bytes_read, 1048576)


### PR DESCRIPTION
Allow passing `stdin` instead of `stdin .buffer` in a CGI scenario.