### PR TITLE
Allow digits and valid token chars in headers

### DIFF
--- a/tests/test_data/http/bad_header_char.http
+++ b/tests/test_data/http/bad_header_char.http
@@ -1,5 +1,5 @@
 ------WebKitFormBoundaryTkr3kCBQlBe1nrhc
-Content-999position: form-data; name="field"
+Content-<<<position: form-data; name="field"
 
 This is a test.
 ------WebKitFormBoundaryTkr3kCBQlBe1nrhc--

--- a/tests/test_data/http/header_with_number.http
+++ b/tests/test_data/http/header_with_number.http
@@ -1,0 +1,11 @@
+--b8825ae386be4fdc9644d87e392caad3
+Content-Disposition: form-data; filename="secret.txt"; name="files"
+Content-Type: text/plain; charset=utf-8
+X-Funky-Header-1: bar
+abcdefghijklmnopqrstuvwxyz01234: foo
+ABCDEFGHIJKLMNOPQRSTUVWXYZ56789: bar
+other!#$%&'*+-.^_`|~: baz
+Content-Length: 6
+
+aaaaaa
+--b8825ae386be4fdc9644d87e392caad3--

--- a/tests/test_data/http/header_with_number.yaml
+++ b/tests/test_data/http/header_with_number.yaml
@@ -1,0 +1,7 @@
+boundary: b8825ae386be4fdc9644d87e392caad3
+expected:
+  - name: files
+    type: file
+    file_name: secret.txt
+    data: !!binary |
+      YWFhYWFh


### PR DESCRIPTION
The part header parsing has been extended to allow additional non-alpha characters that are allowed by the http spec.

In general http header field names can contain a variety of non-alpha characters, yet the present code only allows for a hyphen in addition to alphabetic characters. For multipart/form-data this may not be a a problem since additional headers are discouraged. For other multipart types, such as `related` and `mixed`, it may be an issue.

Since there was a test explicitly checking for failure with numbers in the header name, this seems to been an active choice. I altered this test to replace the numbers with characters forbidden by the spec.

The `lower_char` function  was removed because it was no longer used.