### PR TITLE
Add  mypy strict typing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         run: uv sync --python ${{ matrix.python-version }} --frozen
 
       - name: Run linters
-        run: scripts/lint
+        run: scripts/check
 
       - name: Run tests
         run: scripts/test

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.ruff_cache/
 cover/
 
 # Translations

--- a/multipart/decoders.py
+++ b/multipart/decoders.py
@@ -1,8 +1,23 @@
 import base64
 import binascii
-from io import BufferedWriter
+from typing import TYPE_CHECKING
 
 from .exceptions import DecodeError
+
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import Protocol, TypeVar
+
+
+    _T_contra = TypeVar("_T_contra", contravariant=True)
+
+    class SupportsWrite(Protocol[_T_contra]):
+        def write(self, __b:_T_contra) ->object: ...
+
+        # No way to specify optional methods. See
+        # https://github.com/python/typing/issues/601
+        # close() [Optional]
+        # finalize() [Optional]
+
 
 
 class Base64Decoder:
@@ -34,7 +49,7 @@ class Base64Decoder:
     :param underlying: the underlying object to pass writes to
     """
 
-    def __init__(self, underlying: BufferedWriter):
+    def __init__(self, underlying: 'SupportsWrite[bytes]') -> None:
         self.cache = bytearray()
         self.underlying = underlying
 
@@ -67,9 +82,9 @@ class Base64Decoder:
         # Get the remaining bytes and save in our cache.
         remaining_len = len(data) % 4
         if remaining_len > 0:
-            self.cache = data[-remaining_len:]
+            self.cache[:] = data[-remaining_len:]
         else:
-            self.cache = b""
+            self.cache[:] = b""
 
         # Return the length of the data to indicate no error.
         return len(data)
@@ -112,7 +127,7 @@ class QuotedPrintableDecoder:
     :param underlying: the underlying object to pass writes to
     """
 
-    def __init__(self, underlying: BufferedWriter) -> None:
+    def __init__(self, underlying: 'SupportsWrite[bytes]') -> None:
         self.cache = b""
         self.underlying = underlying
 

--- a/multipart/decoders.py
+++ b/multipart/decoders.py
@@ -7,17 +7,15 @@ from .exceptions import DecodeError
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Protocol, TypeVar
 
-
     _T_contra = TypeVar("_T_contra", contravariant=True)
 
     class SupportsWrite(Protocol[_T_contra]):
-        def write(self, __b:_T_contra) ->object: ...
+        def write(self, __b: _T_contra) -> object: ...
 
         # No way to specify optional methods. See
         # https://github.com/python/typing/issues/601
         # close() [Optional]
         # finalize() [Optional]
-
 
 
 class Base64Decoder:
@@ -49,7 +47,7 @@ class Base64Decoder:
     :param underlying: the underlying object to pass writes to
     """
 
-    def __init__(self, underlying: 'SupportsWrite[bytes]') -> None:
+    def __init__(self, underlying: "SupportsWrite[bytes]") -> None:
         self.cache = bytearray()
         self.underlying = underlying
 
@@ -127,7 +125,7 @@ class QuotedPrintableDecoder:
     :param underlying: the underlying object to pass writes to
     """
 
-    def __init__(self, underlying: 'SupportsWrite[bytes]') -> None:
+    def __init__(self, underlying: "SupportsWrite[bytes]") -> None:
         self.cache = b""
         self.underlying = underlying
 

--- a/multipart/multipart.py
+++ b/multipart/multipart.py
@@ -162,6 +162,7 @@ TOKEN_CHARS_SET = frozenset(
     b"!#$%&'*+-.^_`|~")
 # fmt: on
 
+
 def parse_options_header(value: str | bytes | None) -> tuple[bytes, dict[bytes, bytes]]:
     """Parses a Content-Type header into a value in the following format: (content_type, {parameters})."""
     # Uses email.message.Message to parse the header as described in PEP 594.
@@ -508,7 +509,7 @@ class File:
             if isinstance(tmp_file.name, str):
                 fname = tmp_file.name.encode(sys.getfilesystemencoding())
             else:
-                fname = cast(bytes, tmp_file.name)
+                fname = cast(bytes, tmp_file.name)  # pragma: no cover
 
         self._actual_file_name = fname
         return tmp_file
@@ -597,7 +598,7 @@ class BaseParser:
         self.callbacks: QuerystringCallbacks | OctetStreamCallbacks | MultipartCallbacks = {}
 
     def callback(
-        self, name: CALLBACK_NAMES, data: bytes | None = None, start: int | None = None, end: int | None = None
+        self, name: CallbackName, data: bytes | None = None, start: int | None = None, end: int | None = None
     ) -> None:
         """This function calls a provided callback with some data.  If the
         callback is not set, will do nothing.
@@ -626,7 +627,7 @@ class BaseParser:
             self.logger.debug("Calling %s with no data", on_name)
             func()
 
-    def set_callback(self, name: CALLBACK_NAMES, new_func: Callable[..., Any] | None) -> None:
+    def set_callback(self, name: CallbackName, new_func: Callable[..., Any] | None) -> None:
         """Update the function for a callback.  Removes from the callbacks dict
         if new_func is None.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ dev-dependencies = [
     "invoke==2.2.0",
     "pytest-timeout==2.3.1",
     "ruff==0.3.4",
+    "mypy",
+    "types-PyYAML",
     "atheris==2.3.0; python_version != '3.12'",
     # Documentation
     "mkdocs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ packages = ["multipart"]
 [tool.hatch.build.targets.sdist]
 include = ["/multipart", "/tests", "CHANGELOG.md", "LICENSE.txt"]
 
+[tool.mypy]
+strict = true
+
 [tool.ruff]
 line-length = 120
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,8 @@
+# Development Scripts
+
+* `scripts/setup` - Install dependencies.
+* `scripts/test` - Run the test suite.
+* `scripts/lint` - Run the code format.
+* `scripts/check` - Run the lint in check mode, and the type checker.
+
+Styled after GitHub's ["Scripts to Rule Them All"](https://github.com/github/scripts-to-rule-them-all).

--- a/scripts/check
+++ b/scripts/check
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+set -x
+
+SOURCE_FILES="multipart tests"
+
+uvx ruff format --check --diff $SOURCE_FILES
+uvx ruff check $SOURCE_FILES
+uvx --from types-PyYAML mypy $SOURCE_FILES

--- a/scripts/check
+++ b/scripts/check
@@ -6,4 +6,4 @@ SOURCE_FILES="multipart tests"
 
 uvx ruff format --check --diff $SOURCE_FILES
 uvx ruff check $SOURCE_FILES
-uvx --from types-PyYAML mypy $SOURCE_FILES
+uvx --with types-PyYAML mypy $SOURCE_FILES

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,3 @@
+#!/bin/sh -ex
+
+uv sync --frozen

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any, Callable
 
+
 def ensure_in_path(path: str) -> None:
     """
     Ensure that a given path is in the sys.path array
@@ -83,7 +84,9 @@ class ParametrizingMetaclass(type):
                 new_name = attr.__name__ + "__" + human
 
                 # Create a replacement function.
-                def create_new_func(func: types.FunctionType, names: list[str], values: list[Any]) -> Callable[...,Any]:
+                def create_new_func(
+                    func: types.FunctionType, names: list[str], values: list[Any]
+                ) -> Callable[..., Any]:
                     # Create a kwargs dictionary.
                     kwargs = dict(zip(names, values))
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
 
     from multipart.multipart import FieldProtocol, FileConfig, FileProtocol
 
-
     class TestParams(TypedDict):
         name: str
         test: bytes
@@ -119,7 +118,7 @@ class TestFile(unittest.TestCase):
         f.truncate()
 
     def assert_exists(self) -> None:
-        assert(self.f.actual_file_name is not None)
+        assert self.f.actual_file_name is not None
         full_path = os.path.join(self.d, self.f.actual_file_name)
         self.assertTrue(os.path.exists(full_path))
 
@@ -212,7 +211,7 @@ class TestFile(unittest.TestCase):
         self.assertFalse(self.f.in_memory)
 
         # Assert that the file exists
-        assert(self.f.actual_file_name is not None)
+        assert self.f.actual_file_name is not None
         ext = os.path.splitext(self.f.actual_file_name)[1]
         self.assertEqual(ext, b".txt")
         self.assert_exists()
@@ -310,12 +309,12 @@ class TestBaseParser(unittest.TestCase):
             nonlocal called
             called += 1
 
-        self.b.set_callback("foo", on_foo) # type: ignore[arg-type]
-        self.b.callback("foo") # type: ignore[arg-type]
+        self.b.set_callback("foo", on_foo)  # type: ignore[arg-type]
+        self.b.callback("foo")  # type: ignore[arg-type]
         self.assertEqual(called, 1)
 
-        self.b.set_callback("foo", None) # type: ignore[arg-type]
-        self.b.callback("foo") # type: ignore[arg-type]
+        self.b.set_callback("foo", None)  # type: ignore[arg-type]
+        self.b.callback("foo")  # type: ignore[arg-type]
         self.assertEqual(called, 1)
 
 
@@ -326,7 +325,7 @@ class TestQuerystringParser(unittest.TestCase):
 
         self.assertEqual(self.f, list(args))
         if kwargs.get("reset", True):
-            self.f: list[tuple[bytes, bytes]]  = []
+            self.f: list[tuple[bytes, bytes]] = []
 
     def setUp(self) -> None:
         self.reset()
@@ -491,17 +490,17 @@ class TestOctetStreamParser(unittest.TestCase):
 
         self.p = OctetStreamParser(callbacks={"on_start": on_start, "on_data": on_data, "on_end": on_end})
 
-    def assert_data(self, data: bytes, finalize: bool=True) -> None:
+    def assert_data(self, data: bytes, finalize: bool = True) -> None:
         self.assertEqual(b"".join(self.d), data)
         self.d = []
 
-    def assert_started(self, val: bool=True) -> None:
+    def assert_started(self, val: bool = True) -> None:
         if val:
             self.assertEqual(self.started, 1)
         else:
             self.assertEqual(self.started, 0)
 
-    def assert_finished(self, val: bool=True) -> None:
+    def assert_finished(self, val: bool = True) -> None:
         if val:
             self.assertEqual(self.finished, 1)
         else:
@@ -541,7 +540,7 @@ class TestOctetStreamParser(unittest.TestCase):
 
     def test_invalid_max_size(self) -> None:
         with self.assertRaises(ValueError):
-            q = OctetStreamParser(max_size="foo") # type: ignore[arg-type]
+            q = OctetStreamParser(max_size="foo")  # type: ignore[arg-type]
 
 
 class TestBase64Decoder(unittest.TestCase):
@@ -550,7 +549,7 @@ class TestBase64Decoder(unittest.TestCase):
         self.f = BytesIO()
         self.d = Base64Decoder(self.f)
 
-    def assert_data(self, data: bytes, finalize: bool=True) -> None:
+    def assert_data(self, data: bytes, finalize: bool = True) -> None:
         if finalize:
             self.d.finalize()
 
@@ -614,7 +613,7 @@ class TestQuotedPrintableDecoder(unittest.TestCase):
         self.f = BytesIO()
         self.d = QuotedPrintableDecoder(self.f)
 
-    def assert_data(self, data: bytes, finalize: bool=True) -> None:
+    def assert_data(self, data: bytes, finalize: bool = True) -> None:
         if finalize:
             self.d.finalize()
 
@@ -727,16 +726,16 @@ def split_all(val: bytes) -> Iterator[tuple[bytes, bytes]]:
 
 @parametrize_class
 class TestFormParser(unittest.TestCase):
-    def make(self, boundary: str | bytes, config: dict[str, Any]={}) -> None:
+    def make(self, boundary: str | bytes, config: dict[str, Any] = {}) -> None:
         self.ended = False
         self.files: list[File] = []
         self.fields: list[Field] = []
 
         def on_field(f: FieldProtocol) -> None:
-            self.fields.append(cast(Field,f))
+            self.fields.append(cast(Field, f))
 
         def on_file(f: FileProtocol) -> None:
-            self.files.append(cast(File,f))
+            self.files.append(cast(File, f))
 
         def on_end() -> None:
             self.ended = True
@@ -750,7 +749,7 @@ class TestFormParser(unittest.TestCase):
         file_data = o.read()
         self.assertEqual(file_data, data)
 
-    def assert_file(self, field_name: bytes, file_name:bytes, data: bytes) -> None:
+    def assert_file(self, field_name: bytes, file_name: bytes, data: bytes) -> None:
         # Find this file.
         found = None
         for f in self.files:
@@ -760,7 +759,7 @@ class TestFormParser(unittest.TestCase):
 
         # Assert that we found it.
         self.assertIsNotNone(found)
-        assert(found is not None)
+        assert found is not None
 
         try:
             # Assert about this file.
@@ -783,7 +782,7 @@ class TestFormParser(unittest.TestCase):
 
         # Assert that it exists and matches.
         self.assertIsNotNone(found)
-        assert(found is not None) # typing
+        assert found is not None  # typing
         self.assertEqual(value, found.value)
 
         # Remove it for future iterations.
@@ -814,7 +813,7 @@ class TestFormParser(unittest.TestCase):
         # Do we expect an error?
         if "error" in param["result"]["expected"]:
             self.assertIsNotNone(exc)
-            assert(exc is not None)
+            assert exc is not None
             self.assertEqual(param["result"]["expected"]["error"], exc.offset)
             return
 
@@ -1063,7 +1062,7 @@ class TestFormParser(unittest.TestCase):
         files: list[File] = []
 
         def on_file(f: FileProtocol) -> None:
-            files.append(cast(File,f))
+            files.append(cast(File, f))
 
         on_field = Mock()
         on_end = Mock()
@@ -1084,7 +1083,7 @@ class TestFormParser(unittest.TestCase):
     def test_querystring(self) -> None:
         fields: list[Field] = []
 
-        def on_field(f: FieldProtocol) ->None:
+        def on_field(f: FieldProtocol) -> None:
             fields.append(cast(Field, f))
 
         on_file = Mock()
@@ -1156,7 +1155,7 @@ class TestFormParser(unittest.TestCase):
         files: list[File] = []
 
         def on_file(f: FileProtocol) -> None:
-            files.append(cast(File,f))
+            files.append(cast(File, f))
 
         on_field = Mock()
         on_end = Mock()
@@ -1181,7 +1180,7 @@ class TestFormParser(unittest.TestCase):
         fields: list[Field] = []
 
         def on_field(f: FieldProtocol) -> None:
-            fields.append(cast(Field,f))
+            fields.append(cast(Field, f))
 
         on_file = Mock()
         on_end = Mock()
@@ -1210,7 +1209,7 @@ class TestFormParser(unittest.TestCase):
 
         # Set the maximum length that we can process to be halfway through the
         # given data.
-        assert(self.f.parser is not None)
+        assert self.f.parser is not None
         self.f.parser.max_size = float(len(test_data)) / 2
 
         i = self.f.write(test_data)
@@ -1240,7 +1239,7 @@ class TestFormParser(unittest.TestCase):
         files: list[File] = []
 
         def on_file(f: FileProtocol) -> None:
-            files.append(cast(File,f))
+            files.append(cast(File, f))
 
         on_field = Mock()
         on_end = Mock()
@@ -1261,7 +1260,7 @@ class TestFormParser(unittest.TestCase):
 
     def test_invalid_max_size_multipart(self) -> None:
         with self.assertRaises(ValueError):
-            MultipartParser(b"bound", max_size="foo") # type: ignore[arg-type]
+            MultipartParser(b"bound", max_size="foo")  # type: ignore[arg-type]
 
     def test_header_begin_callback(self) -> None:
         """
@@ -1332,7 +1331,7 @@ class TestHelperFunctions(unittest.TestCase):
         )
 
         self.assertEqual(len(files), 1)
-        self.assertEqual(files[0].size, 10) # type: ignore[attr-defined]
+        self.assertEqual(files[0].size, 10)  # type: ignore[attr-defined]
 
 
 def suite() -> unittest.TestSuite:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -6,13 +6,13 @@ import sys
 import tempfile
 import unittest
 from io import BytesIO
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from unittest.mock import Mock
 
 import yaml
 
 from multipart.decoders import Base64Decoder, QuotedPrintableDecoder
-from multipart.exceptions import DecodeError, FileError, FormParserError, MultipartParseError
+from multipart.exceptions import DecodeError, FileError, FormParserError, MultipartParseError, QuerystringParseError
 from multipart.multipart import (
     BaseParser,
     Field,
@@ -20,7 +20,6 @@ from multipart.multipart import (
     FormParser,
     MultipartParser,
     OctetStreamParser,
-    QuerystringParseError,
     QuerystringParser,
     create_form_parser,
     parse_form,
@@ -30,13 +29,22 @@ from multipart.multipart import (
 from .compat import parametrize, parametrize_class
 
 if TYPE_CHECKING:
-    from multipart.multipart import FileConfig
+    from typing import Any, Iterator, TypedDict
+
+    from multipart.multipart import FieldProtocol, FileConfig, FileProtocol
+
+
+    class TestParams(TypedDict):
+        name: str
+        test: bytes
+        result: Any
+
 
 # Get the current directory for our later test cases.
 curr_dir = os.path.abspath(os.path.dirname(__file__))
 
 
-def force_bytes(val):
+def force_bytes(val: str | bytes) -> bytes:
     if isinstance(val, str):
         val = val.encode(sys.getfilesystemencoding())
 
@@ -44,33 +52,33 @@ def force_bytes(val):
 
 
 class TestField(unittest.TestCase):
-    def setUp(self):
-        self.f = Field("foo")
+    def setUp(self) -> None:
+        self.f = Field(b"foo")
 
-    def test_name(self):
-        self.assertEqual(self.f.field_name, "foo")
+    def test_name(self) -> None:
+        self.assertEqual(self.f.field_name, b"foo")
 
-    def test_data(self):
+    def test_data(self) -> None:
         self.f.write(b"test123")
         self.assertEqual(self.f.value, b"test123")
 
-    def test_cache_expiration(self):
+    def test_cache_expiration(self) -> None:
         self.f.write(b"test")
         self.assertEqual(self.f.value, b"test")
         self.f.write(b"123")
         self.assertEqual(self.f.value, b"test123")
 
-    def test_finalize(self):
+    def test_finalize(self) -> None:
         self.f.write(b"test123")
         self.f.finalize()
         self.assertEqual(self.f.value, b"test123")
 
-    def test_close(self):
+    def test_close(self) -> None:
         self.f.write(b"test123")
         self.f.close()
         self.assertEqual(self.f.value, b"test123")
 
-    def test_from_value(self):
+    def test_from_value(self) -> None:
         f = Field.from_value(b"name", b"value")
         self.assertEqual(f.field_name, b"name")
         self.assertEqual(f.value, b"value")
@@ -78,18 +86,18 @@ class TestField(unittest.TestCase):
         f2 = Field.from_value(b"name", None)
         self.assertEqual(f2.value, None)
 
-    def test_equality(self):
+    def test_equality(self) -> None:
         f1 = Field.from_value(b"name", b"value")
         f2 = Field.from_value(b"name", b"value")
 
         self.assertEqual(f1, f2)
 
-    def test_equality_with_other(self):
+    def test_equality_with_other(self) -> None:
         f = Field.from_value(b"foo", b"bar")
         self.assertFalse(f == b"foo")
         self.assertFalse(b"foo" == f)
 
-    def test_set_none(self):
+    def test_set_none(self) -> None:
         f = Field(b"foo")
         self.assertEqual(f.value, b"")
 
@@ -98,34 +106,35 @@ class TestField(unittest.TestCase):
 
 
 class TestFile(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.c: FileConfig = {}
         self.d = force_bytes(tempfile.mkdtemp())
         self.f = File(b"foo.txt", config=self.c)
 
-    def assert_data(self, data):
+    def assert_data(self, data: bytes) -> None:
         f = self.f.file_object
         f.seek(0)
         self.assertEqual(f.read(), data)
         f.seek(0)
         f.truncate()
 
-    def assert_exists(self):
+    def assert_exists(self) -> None:
+        assert(self.f.actual_file_name is not None)
         full_path = os.path.join(self.d, self.f.actual_file_name)
         self.assertTrue(os.path.exists(full_path))
 
-    def test_simple(self):
+    def test_simple(self) -> None:
         self.f.write(b"foobar")
         self.assert_data(b"foobar")
 
-    def test_invalid_write(self):
+    def test_invalid_write(self) -> None:
         m = Mock()
         m.write.return_value = 5
         self.f._fileobj = m
         v = self.f.write(b"foobar")
         self.assertEqual(v, 5)
 
-    def test_file_fallback(self):
+    def test_file_fallback(self) -> None:
         self.c["MAX_MEMORY_FILE_SIZE"] = 1
 
         self.f.write(b"1")
@@ -142,7 +151,7 @@ class TestFile(unittest.TestCase):
         self.assertFalse(self.f.in_memory)
         self.assertIs(self.f.file_object, old_obj)
 
-    def test_file_fallback_with_data(self):
+    def test_file_fallback_with_data(self) -> None:
         self.c["MAX_MEMORY_FILE_SIZE"] = 10
 
         self.f.write(b"1" * 10)
@@ -153,7 +162,7 @@ class TestFile(unittest.TestCase):
 
         self.assert_data(b"11111111112222222222")
 
-    def test_file_name(self):
+    def test_file_name(self) -> None:
         # Write to this dir.
         self.c["UPLOAD_DIR"] = self.d
         self.c["MAX_MEMORY_FILE_SIZE"] = 10
@@ -166,7 +175,7 @@ class TestFile(unittest.TestCase):
         self.assertIsNotNone(self.f.actual_file_name)
         self.assert_exists()
 
-    def test_file_full_name(self):
+    def test_file_full_name(self) -> None:
         # Write to this dir.
         self.c["UPLOAD_DIR"] = self.d
         self.c["UPLOAD_KEEP_FILENAME"] = True
@@ -180,7 +189,7 @@ class TestFile(unittest.TestCase):
         self.assertEqual(self.f.actual_file_name, b"foo")
         self.assert_exists()
 
-    def test_file_full_name_with_ext(self):
+    def test_file_full_name_with_ext(self) -> None:
         self.c["UPLOAD_DIR"] = self.d
         self.c["UPLOAD_KEEP_FILENAME"] = True
         self.c["UPLOAD_KEEP_EXTENSIONS"] = True
@@ -194,7 +203,7 @@ class TestFile(unittest.TestCase):
         self.assertEqual(self.f.actual_file_name, b"foo.txt")
         self.assert_exists()
 
-    def test_no_dir_with_extension(self):
+    def test_no_dir_with_extension(self) -> None:
         self.c["UPLOAD_KEEP_EXTENSIONS"] = True
         self.c["MAX_MEMORY_FILE_SIZE"] = 10
 
@@ -203,11 +212,12 @@ class TestFile(unittest.TestCase):
         self.assertFalse(self.f.in_memory)
 
         # Assert that the file exists
+        assert(self.f.actual_file_name is not None)
         ext = os.path.splitext(self.f.actual_file_name)[1]
         self.assertEqual(ext, b".txt")
         self.assert_exists()
 
-    def test_invalid_dir_with_name(self):
+    def test_invalid_dir_with_name(self) -> None:
         # Write to this dir.
         self.c["UPLOAD_DIR"] = force_bytes(os.path.join("/", "tmp", "notexisting"))
         self.c["UPLOAD_KEEP_FILENAME"] = True
@@ -217,7 +227,7 @@ class TestFile(unittest.TestCase):
         with self.assertRaises(FileError):
             self.f.write(b"1234567890")
 
-    def test_invalid_dir_no_name(self):
+    def test_invalid_dir_no_name(self) -> None:
         # Write to this dir.
         self.c["UPLOAD_DIR"] = force_bytes(os.path.join("/", "tmp", "notexisting"))
         self.c["UPLOAD_KEEP_FILENAME"] = False
@@ -231,50 +241,50 @@ class TestFile(unittest.TestCase):
 
 
 class TestParseOptionsHeader(unittest.TestCase):
-    def test_simple(self):
+    def test_simple(self) -> None:
         t, p = parse_options_header("application/json")
         self.assertEqual(t, b"application/json")
         self.assertEqual(p, {})
 
-    def test_blank(self):
+    def test_blank(self) -> None:
         t, p = parse_options_header("")
         self.assertEqual(t, b"")
         self.assertEqual(p, {})
 
-    def test_single_param(self):
+    def test_single_param(self) -> None:
         t, p = parse_options_header("application/json;par=val")
         self.assertEqual(t, b"application/json")
         self.assertEqual(p, {b"par": b"val"})
 
-    def test_single_param_with_spaces(self):
+    def test_single_param_with_spaces(self) -> None:
         t, p = parse_options_header(b"application/json;     par=val")
         self.assertEqual(t, b"application/json")
         self.assertEqual(p, {b"par": b"val"})
 
-    def test_multiple_params(self):
+    def test_multiple_params(self) -> None:
         t, p = parse_options_header(b"application/json;par=val;asdf=foo")
         self.assertEqual(t, b"application/json")
         self.assertEqual(p, {b"par": b"val", b"asdf": b"foo"})
 
-    def test_quoted_param(self):
+    def test_quoted_param(self) -> None:
         t, p = parse_options_header(b'application/json;param="quoted"')
         self.assertEqual(t, b"application/json")
         self.assertEqual(p, {b"param": b"quoted"})
 
-    def test_quoted_param_with_semicolon(self):
+    def test_quoted_param_with_semicolon(self) -> None:
         t, p = parse_options_header(b'application/json;param="quoted;with;semicolons"')
         self.assertEqual(p[b"param"], b"quoted;with;semicolons")
 
-    def test_quoted_param_with_escapes(self):
+    def test_quoted_param_with_escapes(self) -> None:
         t, p = parse_options_header(b'application/json;param="This \\" is \\" a \\" quote"')
         self.assertEqual(p[b"param"], b'This " is " a " quote')
 
-    def test_handles_ie6_bug(self):
+    def test_handles_ie6_bug(self) -> None:
         t, p = parse_options_header(b'text/plain; filename="C:\\this\\is\\a\\path\\file.txt"')
 
         self.assertEqual(p[b"filename"], b"file.txt")
 
-    def test_redos_attack_header(self):
+    def test_redos_attack_header(self) -> None:
         t, p = parse_options_header(
             b'application/x-www-form-urlencoded; !="'
             b"\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"
@@ -282,47 +292,47 @@ class TestParseOptionsHeader(unittest.TestCase):
         # If vulnerable, this test wouldn't finish, the line above would hang
         self.assertIn(b'"\\', p[b"!"])
 
-    def test_handles_rfc_2231(self):
+    def test_handles_rfc_2231(self) -> None:
         t, p = parse_options_header(b"text/plain; param*=us-ascii'en-us'encoded%20message")
 
         self.assertEqual(p[b"param"], b"encoded message")
 
 
 class TestBaseParser(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.b = BaseParser()
         self.b.callbacks = {}
 
-    def test_callbacks(self):
+    def test_callbacks(self) -> None:
         called = 0
 
-        def on_foo():
+        def on_foo() -> None:
             nonlocal called
             called += 1
 
-        self.b.set_callback("foo", on_foo)
-        self.b.callback("foo")
+        self.b.set_callback("foo", on_foo) # type: ignore[arg-type]
+        self.b.callback("foo") # type: ignore[arg-type]
         self.assertEqual(called, 1)
 
-        self.b.set_callback("foo", None)
-        self.b.callback("foo")
+        self.b.set_callback("foo", None) # type: ignore[arg-type]
+        self.b.callback("foo") # type: ignore[arg-type]
         self.assertEqual(called, 1)
 
 
 class TestQuerystringParser(unittest.TestCase):
-    def assert_fields(self, *args, **kwargs):
+    def assert_fields(self, *args: tuple[bytes, bytes], **kwargs: Any) -> None:
         if kwargs.pop("finalize", True):
             self.p.finalize()
 
         self.assertEqual(self.f, list(args))
         if kwargs.get("reset", True):
-            self.f = []
+            self.f: list[tuple[bytes, bytes]]  = []
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.reset()
 
-    def reset(self):
-        self.f: list[tuple[bytes, bytes]] = []
+    def reset(self) -> None:
+        self.f = []
 
         name_buffer: list[bytes] = []
         data_buffer: list[bytes] = []
@@ -333,7 +343,7 @@ class TestQuerystringParser(unittest.TestCase):
         def on_field_data(data: bytes, start: int, end: int) -> None:
             data_buffer.append(data[start:end])
 
-        def on_field_end():
+        def on_field_end() -> None:
             self.f.append((b"".join(name_buffer), b"".join(data_buffer)))
 
             del name_buffer[:]
@@ -343,34 +353,34 @@ class TestQuerystringParser(unittest.TestCase):
             callbacks={"on_field_name": on_field_name, "on_field_data": on_field_data, "on_field_end": on_field_end}
         )
 
-    def test_simple_querystring(self):
+    def test_simple_querystring(self) -> None:
         self.p.write(b"foo=bar")
 
         self.assert_fields((b"foo", b"bar"))
 
-    def test_querystring_blank_beginning(self):
+    def test_querystring_blank_beginning(self) -> None:
         self.p.write(b"&foo=bar")
 
         self.assert_fields((b"foo", b"bar"))
 
-    def test_querystring_blank_end(self):
+    def test_querystring_blank_end(self) -> None:
         self.p.write(b"foo=bar&")
 
         self.assert_fields((b"foo", b"bar"))
 
-    def test_multiple_querystring(self):
+    def test_multiple_querystring(self) -> None:
         self.p.write(b"foo=bar&asdf=baz")
 
         self.assert_fields((b"foo", b"bar"), (b"asdf", b"baz"))
 
-    def test_streaming_simple(self):
+    def test_streaming_simple(self) -> None:
         self.p.write(b"foo=bar&")
         self.assert_fields((b"foo", b"bar"), finalize=False)
 
         self.p.write(b"asdf=baz")
         self.assert_fields((b"asdf", b"baz"))
 
-    def test_streaming_break(self):
+    def test_streaming_break(self) -> None:
         self.p.write(b"foo=one")
         self.assert_fields(finalize=False)
 
@@ -386,12 +396,12 @@ class TestQuerystringParser(unittest.TestCase):
         self.p.write(b"f=baz")
         self.assert_fields((b"asdf", b"baz"))
 
-    def test_semicolon_separator(self):
+    def test_semicolon_separator(self) -> None:
         self.p.write(b"foo=bar;asdf=baz")
 
         self.assert_fields((b"foo", b"bar"), (b"asdf", b"baz"))
 
-    def test_too_large_field(self):
+    def test_too_large_field(self) -> None:
         self.p.max_size = 15
 
         # Note: len = 8
@@ -402,11 +412,11 @@ class TestQuerystringParser(unittest.TestCase):
         self.p.write(b"a=123456")
         self.assert_fields((b"a", b"12345"))
 
-    def test_invalid_max_size(self):
+    def test_invalid_max_size(self) -> None:
         with self.assertRaises(ValueError):
             p = QuerystringParser(max_size=-100)
 
-    def test_strict_parsing_pass(self):
+    def test_strict_parsing_pass(self) -> None:
         data = b"foo=bar&another=asdf"
         for first, last in split_all(data):
             self.reset()
@@ -418,7 +428,7 @@ class TestQuerystringParser(unittest.TestCase):
             self.p.write(last)
             self.assert_fields((b"foo", b"bar"), (b"another", b"asdf"))
 
-    def test_strict_parsing_fail_double_sep(self):
+    def test_strict_parsing_fail_double_sep(self) -> None:
         data = b"foo=bar&&another=asdf"
         for first, last in split_all(data):
             self.reset()
@@ -435,7 +445,7 @@ class TestQuerystringParser(unittest.TestCase):
             if cm is not None:
                 self.assertEqual(cm.exception.offset, 8 - cnt)
 
-    def test_double_sep(self):
+    def test_double_sep(self) -> None:
         data = b"foo=bar&&another=asdf"
         for first, last in split_all(data):
             print(f" {first!r} / {last!r} ")
@@ -447,7 +457,7 @@ class TestQuerystringParser(unittest.TestCase):
 
             self.assert_fields((b"foo", b"bar"), (b"another", b"asdf"))
 
-    def test_strict_parsing_fail_no_value(self):
+    def test_strict_parsing_fail_no_value(self) -> None:
         self.p.strict_parsing = True
         with self.assertRaises(QuerystringParseError) as cm:
             self.p.write(b"foo=bar&blank&another=asdf")
@@ -455,18 +465,18 @@ class TestQuerystringParser(unittest.TestCase):
         if cm is not None:
             self.assertEqual(cm.exception.offset, 8)
 
-    def test_success_no_value(self):
+    def test_success_no_value(self) -> None:
         self.p.write(b"foo=bar&blank&another=asdf")
         self.assert_fields((b"foo", b"bar"), (b"blank", b""), (b"another", b"asdf"))
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         # Issue #29; verify we don't assert on repr()
         _ignored = repr(self.p)
 
 
 class TestOctetStreamParser(unittest.TestCase):
-    def setUp(self):
-        self.d = []
+    def setUp(self) -> None:
+        self.d: list[bytes] = []
         self.started = 0
         self.finished = 0
 
@@ -481,23 +491,23 @@ class TestOctetStreamParser(unittest.TestCase):
 
         self.p = OctetStreamParser(callbacks={"on_start": on_start, "on_data": on_data, "on_end": on_end})
 
-    def assert_data(self, data, finalize=True):
+    def assert_data(self, data: bytes, finalize: bool=True) -> None:
         self.assertEqual(b"".join(self.d), data)
         self.d = []
 
-    def assert_started(self, val=True):
+    def assert_started(self, val: bool=True) -> None:
         if val:
             self.assertEqual(self.started, 1)
         else:
             self.assertEqual(self.started, 0)
 
-    def assert_finished(self, val=True):
+    def assert_finished(self, val: bool=True) -> None:
         if val:
             self.assertEqual(self.finished, 1)
         else:
             self.assertEqual(self.finished, 0)
 
-    def test_simple(self):
+    def test_simple(self) -> None:
         # Assert is not started
         self.assert_started(False)
 
@@ -511,7 +521,7 @@ class TestOctetStreamParser(unittest.TestCase):
         self.p.finalize()
         self.assert_finished()
 
-    def test_multiple_chunks(self):
+    def test_multiple_chunks(self) -> None:
         self.p.write(b"foo")
         self.p.write(b"bar")
         self.p.write(b"baz")
@@ -520,7 +530,7 @@ class TestOctetStreamParser(unittest.TestCase):
         self.assert_data(b"foobarbaz")
         self.assert_finished()
 
-    def test_max_size(self):
+    def test_max_size(self) -> None:
         self.p.max_size = 5
 
         self.p.write(b"0123456789")
@@ -529,18 +539,18 @@ class TestOctetStreamParser(unittest.TestCase):
         self.assert_data(b"01234")
         self.assert_finished()
 
-    def test_invalid_max_size(self):
+    def test_invalid_max_size(self) -> None:
         with self.assertRaises(ValueError):
-            q = OctetStreamParser(max_size="foo")
+            q = OctetStreamParser(max_size="foo") # type: ignore[arg-type]
 
 
 class TestBase64Decoder(unittest.TestCase):
     # Note: base64('foobar') == 'Zm9vYmFy'
-    def setUp(self):
+    def setUp(self) -> None:
         self.f = BytesIO()
         self.d = Base64Decoder(self.f)
 
-    def assert_data(self, data, finalize=True):
+    def assert_data(self, data: bytes, finalize: bool=True) -> None:
         if finalize:
             self.d.finalize()
 
@@ -549,20 +559,20 @@ class TestBase64Decoder(unittest.TestCase):
         self.f.seek(0)
         self.f.truncate()
 
-    def test_simple(self):
+    def test_simple(self) -> None:
         self.d.write(b"Zm9vYmFy")
         self.assert_data(b"foobar")
 
-    def test_bad(self):
+    def test_bad(self) -> None:
         with self.assertRaises(DecodeError):
             self.d.write(b"Zm9v!mFy")
 
-    def test_split_properly(self):
+    def test_split_properly(self) -> None:
         self.d.write(b"Zm9v")
         self.d.write(b"YmFy")
         self.assert_data(b"foobar")
 
-    def test_bad_split(self):
+    def test_bad_split(self) -> None:
         buff = b"Zm9v"
         for i in range(1, 4):
             first, second = buff[:i], buff[i:]
@@ -572,7 +582,7 @@ class TestBase64Decoder(unittest.TestCase):
             self.d.write(second)
             self.assert_data(b"foo")
 
-    def test_long_bad_split(self):
+    def test_long_bad_split(self) -> None:
         buff = b"Zm9vYmFy"
         for i in range(5, 8):
             first, second = buff[:i], buff[i:]
@@ -582,7 +592,7 @@ class TestBase64Decoder(unittest.TestCase):
             self.d.write(second)
             self.assert_data(b"foobar")
 
-    def test_close_and_finalize(self):
+    def test_close_and_finalize(self) -> None:
         parser = Mock()
         f = Base64Decoder(parser)
 
@@ -592,7 +602,7 @@ class TestBase64Decoder(unittest.TestCase):
         f.close()
         parser.close.assert_called_once_with()
 
-    def test_bad_length(self):
+    def test_bad_length(self) -> None:
         self.d.write(b"Zm9vYmF")  # missing ending 'y'
 
         with self.assertRaises(DecodeError):
@@ -600,11 +610,11 @@ class TestBase64Decoder(unittest.TestCase):
 
 
 class TestQuotedPrintableDecoder(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.f = BytesIO()
         self.d = QuotedPrintableDecoder(self.f)
 
-    def assert_data(self, data, finalize=True):
+    def assert_data(self, data: bytes, finalize: bool=True) -> None:
         if finalize:
             self.d.finalize()
 
@@ -613,38 +623,38 @@ class TestQuotedPrintableDecoder(unittest.TestCase):
         self.f.seek(0)
         self.f.truncate()
 
-    def test_simple(self):
+    def test_simple(self) -> None:
         self.d.write(b"foobar")
         self.assert_data(b"foobar")
 
-    def test_with_escape(self):
+    def test_with_escape(self) -> None:
         self.d.write(b"foo=3Dbar")
         self.assert_data(b"foo=bar")
 
-    def test_with_newline_escape(self):
+    def test_with_newline_escape(self) -> None:
         self.d.write(b"foo=\r\nbar")
         self.assert_data(b"foobar")
 
-    def test_with_only_newline_escape(self):
+    def test_with_only_newline_escape(self) -> None:
         self.d.write(b"foo=\nbar")
         self.assert_data(b"foobar")
 
-    def test_with_split_escape(self):
+    def test_with_split_escape(self) -> None:
         self.d.write(b"foo=3")
         self.d.write(b"Dbar")
         self.assert_data(b"foo=bar")
 
-    def test_with_split_newline_escape_1(self):
+    def test_with_split_newline_escape_1(self) -> None:
         self.d.write(b"foo=\r")
         self.d.write(b"\nbar")
         self.assert_data(b"foobar")
 
-    def test_with_split_newline_escape_2(self):
+    def test_with_split_newline_escape_2(self) -> None:
         self.d.write(b"foo=")
         self.d.write(b"\r\nbar")
         self.assert_data(b"foobar")
 
-    def test_close_and_finalize(self):
+    def test_close_and_finalize(self) -> None:
         parser = Mock()
         f = QuotedPrintableDecoder(parser)
 
@@ -654,7 +664,7 @@ class TestQuotedPrintableDecoder(unittest.TestCase):
         f.close()
         parser.close.assert_called_once_with()
 
-    def test_not_aligned(self):
+    def test_not_aligned(self) -> None:
         """
         https://github.com/andrew-d/python-multipart/issues/6
         """
@@ -675,7 +685,7 @@ http_tests_dir = os.path.join(curr_dir, "test_data", "http")
 
 # Read in all test cases and load them.
 NON_PARAMETRIZED_TESTS = {"single_field_blocks"}
-http_tests = []
+http_tests: list[TestParams] = []
 for f in os.listdir(http_tests_dir):
     # Only load the HTTP test cases.
     fname, ext = os.path.splitext(f)
@@ -687,11 +697,11 @@ for f in os.listdir(http_tests_dir):
         yaml_file = os.path.join(http_tests_dir, fname + ".yaml")
 
         # Load both.
-        with open(os.path.join(http_tests_dir, f), "rb") as f:
-            test_data = f.read()
+        with open(os.path.join(http_tests_dir, f), "rb") as fh:
+            test_data = fh.read()
 
-        with open(yaml_file, "rb") as f:
-            yaml_data = yaml.safe_load(f)
+        with open(yaml_file, "rb") as fy:
+            yaml_data = yaml.safe_load(fy)
 
         http_tests.append({"name": fname, "test": test_data, "result": yaml_data})
 
@@ -704,7 +714,7 @@ single_byte_tests = [
     "single_field_single_file",
 ]
 
-def split_all(val):
+def split_all(val: bytes) -> Iterator[tuple[bytes, bytes]]:
     """
     This function will split an array all possible ways.  For example:
         split_all([1,2,3,4])
@@ -717,30 +727,30 @@ def split_all(val):
 
 @parametrize_class
 class TestFormParser(unittest.TestCase):
-    def make(self, boundary, config={}):
+    def make(self, boundary: str | bytes, config: dict[str, Any]={}) -> None:
         self.ended = False
         self.files: list[File] = []
         self.fields: list[Field] = []
 
-        def on_field(f: Field) -> None:
-            self.fields.append(f)
+        def on_field(f: FieldProtocol) -> None:
+            self.fields.append(cast(Field,f))
 
-        def on_file(f: File) -> None:
-            self.files.append(f)
+        def on_file(f: FileProtocol) -> None:
+            self.files.append(cast(File,f))
 
-        def on_end():
+        def on_end() -> None:
             self.ended = True
 
         # Get a form-parser instance.
         self.f = FormParser("multipart/form-data", on_field, on_file, on_end, boundary=boundary, config=config)
 
-    def assert_file_data(self, f, data):
+    def assert_file_data(self, f: File, data: bytes) -> None:
         o = f.file_object
         o.seek(0)
         file_data = o.read()
         self.assertEqual(file_data, data)
 
-    def assert_file(self, field_name, file_name, data):
+    def assert_file(self, field_name: bytes, file_name:bytes, data: bytes) -> None:
         # Find this file.
         found = None
         for f in self.files:
@@ -750,6 +760,7 @@ class TestFormParser(unittest.TestCase):
 
         # Assert that we found it.
         self.assertIsNotNone(found)
+        assert(found is not None)
 
         try:
             # Assert about this file.
@@ -762,7 +773,7 @@ class TestFormParser(unittest.TestCase):
             # Close our file
             found.close()
 
-    def assert_field(self, name, value):
+    def assert_field(self, name: bytes, value: bytes) -> None:
         # Find this field in our fields list.
         found = None
         for f in self.fields:
@@ -772,13 +783,14 @@ class TestFormParser(unittest.TestCase):
 
         # Assert that it exists and matches.
         self.assertIsNotNone(found)
+        assert(found is not None) # typing
         self.assertEqual(value, found.value)
 
         # Remove it for future iterations.
         self.fields.remove(found)
 
     @parametrize("param", http_tests)
-    def test_http(self, param):
+    def test_http(self, param: TestParams) -> None:
         # Firstly, create our parser with the given boundary.
         boundary = param["result"]["boundary"]
         if isinstance(boundary, str):
@@ -790,9 +802,9 @@ class TestFormParser(unittest.TestCase):
         try:
             processed = self.f.write(param["test"])
             self.f.finalize()
-        except MultipartParseError as e:
+        except MultipartParseError as err:
             processed = 0
-            exc = e
+            exc = err
 
         # print(repr(param))
         # print("")
@@ -802,6 +814,7 @@ class TestFormParser(unittest.TestCase):
         # Do we expect an error?
         if "error" in param["result"]["expected"]:
             self.assertIsNotNone(exc)
+            assert(exc is not None)
             self.assertEqual(param["result"]["expected"]["error"], exc.offset)
             return
 
@@ -823,7 +836,7 @@ class TestFormParser(unittest.TestCase):
             else:
                 assert False
 
-    def test_random_splitting(self):
+    def test_random_splitting(self) -> None:
         """
         This test runs a simple multipart body with one field and one file
         through every possible split.
@@ -852,7 +865,7 @@ class TestFormParser(unittest.TestCase):
             self.assert_file(b"file", b"file.txt", b"test2")
 
     @parametrize("param", [ t for t in http_tests if t["name"] in single_byte_tests])
-    def test_feed_single_bytes(self, param):
+    def test_feed_single_bytes(self, param: TestParams) -> None:
         """
         This test parses multipart bodies 1 byte at a time.
         """
@@ -893,7 +906,7 @@ class TestFormParser(unittest.TestCase):
             else:
                 assert False
 
-    def test_feed_blocks(self):
+    def test_feed_blocks(self) -> None:
         """
         This test parses a simple multipart body 1 byte at a time.
         """
@@ -926,7 +939,7 @@ class TestFormParser(unittest.TestCase):
                 # Assert that our field is here.
                 self.assert_field(b"field", b"0123456789ABCDEFGHIJ0123456789ABCDEFGHIJ")
 
-    def test_request_body_fuzz(self):
+    def test_request_body_fuzz(self) -> None:
         """
         This test randomly fuzzes the request body to ensure that no strange
         exceptions are raised and we don't end up in a strange state.  The
@@ -998,7 +1011,7 @@ class TestFormParser(unittest.TestCase):
         print("Failures:   %d" % (failures,))
         print("Exceptions: %d" % (exceptions,))
 
-    def test_request_body_fuzz_random_data(self):
+    def test_request_body_fuzz_random_data(self) -> None:
         """
         This test will fuzz the multipart parser with some number of iterations
         of randomly-generated data.
@@ -1035,7 +1048,7 @@ class TestFormParser(unittest.TestCase):
         print("Failures:   %d" % (failures,))
         print("Exceptions: %d" % (exceptions,))
 
-    def test_bad_start_boundary(self):
+    def test_bad_start_boundary(self) -> None:
         self.make("boundary")
         data = b"--boundary\rfoobar"
         with self.assertRaises(MultipartParseError):
@@ -1046,11 +1059,11 @@ class TestFormParser(unittest.TestCase):
         with self.assertRaises(MultipartParseError):
             i = self.f.write(data)
 
-    def test_octet_stream(self):
-        files = []
+    def test_octet_stream(self) -> None:
+        files: list[File] = []
 
-        def on_file(f):
-            files.append(f)
+        def on_file(f: FileProtocol) -> None:
+            files.append(cast(File,f))
 
         on_field = Mock()
         on_end = Mock()
@@ -1068,16 +1081,16 @@ class TestFormParser(unittest.TestCase):
         self.assert_file_data(files[0], b"test1234")
         self.assertTrue(on_end.called)
 
-    def test_querystring(self):
-        fields = []
+    def test_querystring(self) -> None:
+        fields: list[Field] = []
 
-        def on_field(f):
-            fields.append(f)
+        def on_field(f: FieldProtocol) ->None:
+            fields.append(cast(Field, f))
 
         on_file = Mock()
         on_end = Mock()
 
-        def simple_test(f):
+        def simple_test(f: FormParser) -> None:
             # Reset tracking.
             del fields[:]
             on_file.reset_mock()
@@ -1110,7 +1123,7 @@ class TestFormParser(unittest.TestCase):
         self.assertTrue(isinstance(f.parser, QuerystringParser))
         simple_test(f)
 
-    def test_close_methods(self):
+    def test_close_methods(self) -> None:
         parser = Mock()
         f = FormParser("application/x-url-encoded", None, None)
         f.parser = parser
@@ -1121,18 +1134,18 @@ class TestFormParser(unittest.TestCase):
         f.close()
         parser.close.assert_called_once_with()
 
-    def test_bad_content_type(self):
+    def test_bad_content_type(self) -> None:
         # We should raise a ValueError for a bad Content-Type
         with self.assertRaises(ValueError):
             f = FormParser("application/bad", None, None)
 
-    def test_no_boundary_given(self):
+    def test_no_boundary_given(self) -> None:
         # We should raise a FormParserError when parsing a multipart message
         # without a boundary.
         with self.assertRaises(FormParserError):
             f = FormParser("multipart/form-data", None, None)
 
-    def test_bad_content_transfer_encoding(self):
+    def test_bad_content_transfer_encoding(self) -> None:
         data = (
             b'----boundary\r\nContent-Disposition: form-data; name="file"; filename="test.txt"\r\n'
             b"Content-Type: text/plain\r\n"
@@ -1140,10 +1153,10 @@ class TestFormParser(unittest.TestCase):
             b"Test\r\n----boundary--\r\n"
         )
 
-        files = []
+        files: list[File] = []
 
-        def on_file(f):
-            files.append(f)
+        def on_file(f: FileProtocol) -> None:
+            files.append(cast(File,f))
 
         on_field = Mock()
         on_end = Mock()
@@ -1164,11 +1177,11 @@ class TestFormParser(unittest.TestCase):
         f.finalize()
         self.assert_file_data(files[0], b"Test")
 
-    def test_handles_None_fields(self):
-        fields = []
+    def test_handles_None_fields(self) -> None:
+        fields: list[Field] = []
 
-        def on_field(f):
-            fields.append(f)
+        def on_field(f: FieldProtocol) -> None:
+            fields.append(cast(Field,f))
 
         on_file = Mock()
         on_end = Mock()
@@ -1186,7 +1199,7 @@ class TestFormParser(unittest.TestCase):
         self.assertEqual(fields[2].field_name, b"baz")
         self.assertEqual(fields[2].value, b"asdf")
 
-    def test_max_size_multipart(self):
+    def test_max_size_multipart(self) -> None:
         # Load test data.
         test_file = "single_field_single_file.http"
         with open(os.path.join(http_tests_dir, test_file), "rb") as f:
@@ -1197,7 +1210,8 @@ class TestFormParser(unittest.TestCase):
 
         # Set the maximum length that we can process to be halfway through the
         # given data.
-        self.f.parser.max_size = len(test_data) / 2
+        assert(self.f.parser is not None)
+        self.f.parser.max_size = float(len(test_data)) / 2
 
         i = self.f.write(test_data)
         self.f.finalize()
@@ -1205,7 +1219,7 @@ class TestFormParser(unittest.TestCase):
         # Assert we processed the correct amount.
         self.assertEqual(i, len(test_data) / 2)
 
-    def test_max_size_form_parser(self):
+    def test_max_size_form_parser(self) -> None:
         # Load test data.
         test_file = "single_field_single_file.http"
         with open(os.path.join(http_tests_dir, test_file), "rb") as f:
@@ -1222,11 +1236,11 @@ class TestFormParser(unittest.TestCase):
         # Assert we processed the correct amount.
         self.assertEqual(i, len(test_data) / 2)
 
-    def test_octet_stream_max_size(self):
-        files = []
+    def test_octet_stream_max_size(self) -> None:
+        files: list[File] = []
 
-        def on_file(f):
-            files.append(f)
+        def on_file(f: FileProtocol) -> None:
+            files.append(cast(File,f))
 
         on_field = Mock()
         on_end = Mock()
@@ -1245,11 +1259,11 @@ class TestFormParser(unittest.TestCase):
 
         self.assert_file_data(files[0], b"0123456789")
 
-    def test_invalid_max_size_multipart(self):
+    def test_invalid_max_size_multipart(self) -> None:
         with self.assertRaises(ValueError):
-            MultipartParser(b"bound", max_size="foo")
+            MultipartParser(b"bound", max_size="foo") # type: ignore[arg-type]
 
-    def test_header_begin_callback(self):
+    def test_header_begin_callback(self) -> None:
         """
         This test verifies we call the `on_header_begin` callback.
         See GitHub issue #23
@@ -1280,20 +1294,20 @@ class TestFormParser(unittest.TestCase):
 
 
 class TestHelperFunctions(unittest.TestCase):
-    def test_create_form_parser(self):
-        r = create_form_parser({"Content-Type": "application/octet-stream"}, None, None)
+    def test_create_form_parser(self) -> None:
+        r = create_form_parser({"Content-Type": b"application/octet-stream"}, None, None)
         self.assertTrue(isinstance(r, FormParser))
 
-    def test_create_form_parser_error(self):
-        headers = {}
+    def test_create_form_parser_error(self) -> None:
+        headers: dict[str, bytes] = {}
         with self.assertRaises(ValueError):
             create_form_parser(headers, None, None)
 
-    def test_parse_form(self):
+    def test_parse_form(self) -> None:
         on_field = Mock()
         on_file = Mock()
 
-        parse_form({"Content-Type": "application/octet-stream"}, BytesIO(b"123456789012345"), on_field, on_file)
+        parse_form({"Content-Type": b"application/octet-stream"}, BytesIO(b"123456789012345"), on_field, on_file)
 
         assert on_file.call_count == 1
 
@@ -1301,24 +1315,27 @@ class TestHelperFunctions(unittest.TestCase):
         # 15 - i.e. all data is written.
         self.assertEqual(on_file.call_args[0][0].size, 15)
 
-    def test_parse_form_content_length(self):
-        files = []
+    def test_parse_form_content_length(self) -> None:
+        files: list[FileProtocol] = []
 
-        def on_file(file):
+        def on_field(field: FieldProtocol) -> None:
+            pass
+
+        def on_file(file: FileProtocol) -> None:
             files.append(file)
 
         parse_form(
-            {"Content-Type": "application/octet-stream", "Content-Length": "10"},
+            {"Content-Type": b"application/octet-stream", "Content-Length": b"10"},
             BytesIO(b"123456789012345"),
-            None,
+            on_field,
             on_file,
         )
 
         self.assertEqual(len(files), 1)
-        self.assertEqual(files[0].size, 10)
+        self.assertEqual(files[0].size, 10) # type: ignore[attr-defined]
 
 
-def suite():
+def suite() -> unittest.TestSuite:
     suite = unittest.TestSuite()
     suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestFile))
     suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestParseOptionsHeader))

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -713,6 +713,7 @@ single_byte_tests = [
     "single_field_single_file",
 ]
 
+
 def split_all(val: bytes) -> Iterator[tuple[bytes, bytes]]:
     """
     This function will split an array all possible ways.  For example:
@@ -863,7 +864,7 @@ class TestFormParser(unittest.TestCase):
             self.assert_field(b"field", b"test1")
             self.assert_file(b"file", b"file.txt", b"test2")
 
-    @parametrize("param", [ t for t in http_tests if t["name"] in single_byte_tests])
+    @parametrize("param", [t for t in http_tests if t["name"] in single_byte_tests])
     def test_feed_single_bytes(self, param: TestParams) -> None:
         """
         This test parses multipart bodies 1 byte at a time.

--- a/uv.lock
+++ b/uv.lock
@@ -525,6 +525,54 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/86/5d7cbc4974fd564550b80fbb8103c05501ea11aa7835edf3351d90095896/mypy-1.11.2.tar.gz", hash = "sha256:7f9993ad3e0ffdc95c2a14b66dee63729f021968bff8ad911867579c65d13a79", size = 3078806 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/cd/815368cd83c3a31873e5e55b317551500b12f2d1d7549720632f32630333/mypy-1.11.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d42a6dd818ffce7be66cce644f1dff482f1d97c53ca70908dff0b9ddc120b77a", size = 10939401 },
+    { url = "https://files.pythonhosted.org/packages/f1/27/e18c93a195d2fad75eb96e1f1cbc431842c332e8eba2e2b77eaf7313c6b7/mypy-1.11.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:801780c56d1cdb896eacd5619a83e427ce436d86a3bdf9112527f24a66618fef", size = 10111697 },
+    { url = "https://files.pythonhosted.org/packages/dc/08/cdc1fc6d0d5a67d354741344cc4aa7d53f7128902ebcbe699ddd4f15a61c/mypy-1.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41ea707d036a5307ac674ea172875f40c9d55c5394f888b168033177fce47383", size = 12500508 },
+    { url = "https://files.pythonhosted.org/packages/64/12/aad3af008c92c2d5d0720ea3b6674ba94a98cdb86888d389acdb5f218c30/mypy-1.11.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6e658bd2d20565ea86da7d91331b0eed6d2eee22dc031579e6297f3e12c758c8", size = 13020712 },
+    { url = "https://files.pythonhosted.org/packages/03/e6/a7d97cc124a565be5e9b7d5c2a6ebf082379ffba99646e4863ed5bbcb3c3/mypy-1.11.2-cp310-cp310-win_amd64.whl", hash = "sha256:478db5f5036817fe45adb7332d927daa62417159d49783041338921dcf646fc7", size = 9567319 },
+    { url = "https://files.pythonhosted.org/packages/e2/aa/cc56fb53ebe14c64f1fe91d32d838d6f4db948b9494e200d2f61b820b85d/mypy-1.11.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:75746e06d5fa1e91bfd5432448d00d34593b52e7e91a187d981d08d1f33d4385", size = 10859630 },
+    { url = "https://files.pythonhosted.org/packages/04/c8/b19a760fab491c22c51975cf74e3d253b8c8ce2be7afaa2490fbf95a8c59/mypy-1.11.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a976775ab2256aadc6add633d44f100a2517d2388906ec4f13231fafbb0eccca", size = 10037973 },
+    { url = "https://files.pythonhosted.org/packages/88/57/7e7e39f2619c8f74a22efb9a4c4eff32b09d3798335625a124436d121d89/mypy-1.11.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd953f221ac1379050a8a646585a29574488974f79d8082cedef62744f0a0104", size = 12416659 },
+    { url = "https://files.pythonhosted.org/packages/fc/a6/37f7544666b63a27e46c48f49caeee388bf3ce95f9c570eb5cfba5234405/mypy-1.11.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:57555a7715c0a34421013144a33d280e73c08df70f3a18a552938587ce9274f4", size = 12897010 },
+    { url = "https://files.pythonhosted.org/packages/84/8b/459a513badc4d34acb31c736a0101c22d2bd0697b969796ad93294165cfb/mypy-1.11.2-cp311-cp311-win_amd64.whl", hash = "sha256:36383a4fcbad95f2657642a07ba22ff797de26277158f1cc7bd234821468b1b6", size = 9562873 },
+    { url = "https://files.pythonhosted.org/packages/35/3a/ed7b12ecc3f6db2f664ccf85cb2e004d3e90bec928e9d7be6aa2f16b7cdf/mypy-1.11.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e8960dbbbf36906c5c0b7f4fbf2f0c7ffb20f4898e6a879fcf56a41a08b0d318", size = 10990335 },
+    { url = "https://files.pythonhosted.org/packages/04/e4/1a9051e2ef10296d206519f1df13d2cc896aea39e8683302f89bf5792a59/mypy-1.11.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:06d26c277962f3fb50e13044674aa10553981ae514288cb7d0a738f495550b36", size = 10007119 },
+    { url = "https://files.pythonhosted.org/packages/f3/3c/350a9da895f8a7e87ade0028b962be0252d152e0c2fbaafa6f0658b4d0d4/mypy-1.11.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e7184632d89d677973a14d00ae4d03214c8bc301ceefcdaf5c474866814c987", size = 12506856 },
+    { url = "https://files.pythonhosted.org/packages/b6/49/ee5adf6a49ff13f4202d949544d3d08abb0ea1f3e7f2a6d5b4c10ba0360a/mypy-1.11.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3a66169b92452f72117e2da3a576087025449018afc2d8e9bfe5ffab865709ca", size = 12952066 },
+    { url = "https://files.pythonhosted.org/packages/27/c0/b19d709a42b24004d720db37446a42abadf844d5c46a2c442e2a074d70d9/mypy-1.11.2-cp312-cp312-win_amd64.whl", hash = "sha256:969ea3ef09617aff826885a22ece0ddef69d95852cdad2f60c8bb06bf1f71f70", size = 9664000 },
+    { url = "https://files.pythonhosted.org/packages/42/ad/5a8567700410f8aa7c755b0ebd4cacff22468cbc5517588773d65075c0cb/mypy-1.11.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:37c7fa6121c1cdfcaac97ce3d3b5588e847aa79b580c1e922bb5d5d2902df19b", size = 10876550 },
+    { url = "https://files.pythonhosted.org/packages/1b/bc/9fc16ea7a27ceb93e123d300f1cfe27a6dd1eac9a8beea4f4d401e737e9d/mypy-1.11.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4a8a53bc3ffbd161b5b2a4fff2f0f1e23a33b0168f1c0778ec70e1a3d66deb86", size = 10068086 },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/a1e460f1288405a13352dad16b24aba6dce4f850fc76510c540faa96eda3/mypy-1.11.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ff93107f01968ed834f4256bc1fc4475e2fecf6c661260066a985b52741ddce", size = 12459214 },
+    { url = "https://files.pythonhosted.org/packages/c7/74/746b31aef7cc7512dab8bdc2311ef88d63fadc1c453a09c8cab7e57e59bf/mypy-1.11.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:edb91dded4df17eae4537668b23f0ff6baf3707683734b6a818d5b9d0c0c31a1", size = 12962942 },
+    { url = "https://files.pythonhosted.org/packages/28/a4/7fae712240b640d75bb859294ad4776b9960b3216ccb7fa747f578e6c632/mypy-1.11.2-cp38-cp38-win_amd64.whl", hash = "sha256:ee23de8530d99b6db0573c4ef4bd8f39a2a6f9b60655bf7a1357e585a3486f2b", size = 9545616 },
+    { url = "https://files.pythonhosted.org/packages/16/64/bb5ed751487e2bea0dfaa6f640a7e3bb88083648f522e766d5ef4a76f578/mypy-1.11.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:801ca29f43d5acce85f8e999b1e431fb479cb02d0e11deb7d2abb56bdaf24fd6", size = 10937294 },
+    { url = "https://files.pythonhosted.org/packages/a9/a3/67a0069abed93c3bf3b0bebb8857e2979a02828a4a3fd82f107f8f1143e8/mypy-1.11.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:af8d155170fcf87a2afb55b35dc1a0ac21df4431e7d96717621962e4b9192e70", size = 10107707 },
+    { url = "https://files.pythonhosted.org/packages/2f/4d/0379daf4258b454b1f9ed589a9dabd072c17f97496daea7b72fdacf7c248/mypy-1.11.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7821776e5c4286b6a13138cc935e2e9b6fde05e081bdebf5cdb2bb97c9df81d", size = 12498367 },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/3976a988c280b3571b8eb6928882dc4b723a403b21735a6d8ae6ed20e82b/mypy-1.11.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:539c570477a96a4e6fb718b8d5c3e0c0eba1f485df13f86d2970c91f0673148d", size = 13018014 },
+    { url = "https://files.pythonhosted.org/packages/83/84/adffc7138fb970e7e2a167bd20b33bb78958370179853a4ebe9008139342/mypy-1.11.2-cp39-cp39-win_amd64.whl", hash = "sha256:3f14cd3d386ac4d05c5a39a51b84387403dadbd936e17cb35882134d4f8f0d24", size = 9568056 },
+    { url = "https://files.pythonhosted.org/packages/42/3a/bdf730640ac523229dd6578e8a581795720a9321399de494374afc437ec5/mypy-1.11.2-py3-none-any.whl", hash = "sha256:b499bc07dbdcd3de92b0a8b29fdf592c111276f6a12fe29c30f6c417dd546d12", size = 2619625 },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -665,7 +713,7 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.10"
+version = "0.0.11"
 source = { editable = "." }
 
 [package.dev-dependencies]
@@ -680,6 +728,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings-python" },
     { name = "more-itertools" },
+    { name = "mypy" },
     { name = "pbr" },
     { name = "pluggy" },
     { name = "py" },
@@ -688,6 +737,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pyyaml" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -704,6 +754,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings-python" },
     { name = "more-itertools", specifier = "==10.2.0" },
+    { name = "mypy" },
     { name = "pbr", specifier = "==6.0.0" },
     { name = "pluggy", specifier = "==1.4.0" },
     { name = "py", specifier = "==1.11.0" },
@@ -712,6 +763,7 @@ dev = [
     { name = "pytest-timeout", specifier = "==2.3.1" },
     { name = "pyyaml", specifier = "==6.0.1" },
     { name = "ruff", specifier = "==0.3.4" },
+    { name = "types-pyyaml" },
 ]
 
 [[package]]
@@ -937,6 +989,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f", size = 15164 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc", size = 12757 },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20240917"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/7d/a95df0a11f95c8f48d7683f03e4aed1a2c0fc73e9de15cca4d38034bea1a/types-PyYAML-6.0.12.20240917.tar.gz", hash = "sha256:d1405a86f9576682234ef83bcb4e6fff7c9305c8b1fbad5e0bcd4f7dbdc9c587", size = 12381 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/2c/c1d81d680997d24b0542aa336f0a65bd7835e5224b7670f33a7d617da379/types_PyYAML-6.0.12.20240917-py3-none-any.whl", hash = "sha256:392b267f1c0fe6022952462bf5d6523f31e37f6cea49b14cee7ad634b6301570", size = 15264 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds typing sufficient to pass `mypy --strict` checks. 

The changes attempt to keep the public-facing API as close to unchanged as possible. 

Internally there are some points that required design choices that are debatable:
- Use of `assert` in the code for type narrowing:  is this "forbidden" here, or not? A few instances were added here. It may have a small performance impact, and could cause some existing code to fail. 
- Some use of `typing.cast`. This should not have an impact, but could also be replaced with `# type: ignore` comments.
- Strict typing in the tests - currently the source in `tests` pass mypy, but I'm not sure test code needs to pass type checks.

I also added mypy to the Github actions.

With the changes, the unit tests pass, and performance (parsing throughput) seems unchanged.