### PR TITLE
fix: add missing files to SDist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ Source = "https://github.com/Kludex/python-multipart"
 path = "python_multipart/__init__.py"
 
 [tool.hatch.build.targets.sdist]
-include = ["/python_multipart", "/tests", "CHANGELOG.md", "LICENSE.txt", "_python_multipart.pth", "_python_multipart_loader.py"]
+include = ["/python_multipart", "/multipart", "/tests", "CHANGELOG.md", "LICENSE.txt"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["python_multipart", "multipart"]


### PR DESCRIPTION
Quick fix for missing files in SDist, which also are missing from the wheel if you build the wheel from the SDist. But not if you build directly, which is why tests were passing. See #168.

```console
$ uvx check-dist
SDist does not match git

SDist only:


Git only:
  docs/CNAME
  docs/api.md
  docs/changelog.md
  docs/index.md
  fuzz/README.md
  fuzz/corpus/fuzz_decoders/fuzz_decoders
  fuzz/corpus/fuzz_form/fuzz_form
  fuzz/corpus/fuzz_options_header/fuzz_options_header
  fuzz/fuzz_decoders.py
  fuzz/fuzz_form.py
  fuzz/fuzz_options_header.py
  fuzz/helpers.py
  mkdocs.yml
  scripts/README.md
  scripts/check
  scripts/lint
  scripts/rename
  scripts/setup
  scripts/test
  uv.lock
```

That looks pretty safe now.
