### PR TITLE
fix: reduce visibility of warning for next release

### DIFF
--- a/multipart/__init__.py
+++ b/multipart/__init__.py
@@ -16,5 +16,5 @@ for p in sys.path:
         spec.loader.exec_module(module)
         break
 else:
-    warnings.warn("Please use `import python_multipart` instead.", FutureWarning, stacklevel=2)
+    warnings.warn("Please use `import python_multipart` instead.", PendingDeprecationWarning, stacklevel=2)
     from python_multipart import *


### PR DESCRIPTION
This reduces the visibility of the warning; you have to have `-Wdefault` or `-Werror` to see it. It can be increased to a FutureWarning in a subsequent release, but this gives packages more time to adapt.

We could remove the warning entirely, but the warning was what I was using to test that it worked, so I think this is better. Happy to change if you'd prefer no warning at all.
