### PR TITLE
Speed up processing junk before or after first or last boundary

### DIFF
--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -1105,7 +1105,6 @@ class MultipartParser(BaseParser):
                 # Skip leading newlines
                 if c == CR or c == LF:
                     i += 1
-                    self.logger.debug("Skipping leading CR/LF at %d", i)
                     continue
 
                 # index is used as in index into our boundary.  Set to 0.
@@ -1398,9 +1397,9 @@ class MultipartParser(BaseParser):
                     i -= 1
 
             elif state == MultipartState.END:
-                # Do nothing and just consume a byte in the end state.
-                if c not in (CR, LF):
-                    self.logger.warning("Consuming a byte '0x%x' in the end state", c)  # pragma: no cover
+                # Skip junk after the last boundary
+                i = length
+                break
 
             else:  # pragma: no cover (error case)
                 # We got into a strange state somehow!  Just stop processing.

--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -1102,6 +1102,14 @@ class MultipartParser(BaseParser):
             c = data[i]
 
             if state == MultipartState.START:
+                # Stop parsing if there is no boundary within the first chunk
+                if i == 16:
+                    msg = "Too much junk in front of first boundary (%d)" % (i,)
+                    self.logger.warning(msg)
+                    e = MultipartParseError(msg)
+                    e.offset = i
+                    raise e
+
                 # Skip leading newlines
                 if c == CR or c == LF:
                     i += 1


### PR DESCRIPTION
This should fix #162 by removing log lines that would trigger once per character of junk before or after the first or last boundary. The parser now skips over junk after the last boundary, and triggers an error if there is too much junk in front of the first boundary. **You may want to cherry-pick only the first commit if you want to stay compliant to the specification**, which requires junk to be accepted and ignored.