### PR TITLE
Handle PermissionError in fallback code for old import name

### DIFF
--- a/multipart/__init__.py
+++ b/multipart/__init__.py
@@ -7,14 +7,17 @@ from pathlib import Path
 
 for p in sys.path:
     file_path = Path(p, "multipart.py")
-    if file_path.is_file():
-        spec = importlib.util.spec_from_file_location("multipart", file_path)
-        assert spec is not None, f"{file_path} found but not loadable!"
-        module = importlib.util.module_from_spec(spec)
-        sys.modules["multipart"] = module
-        assert spec.loader is not None, f"{file_path} must be loadable!"
-        spec.loader.exec_module(module)
-        break
+    try:
+        if file_path.is_file():
+            spec = importlib.util.spec_from_file_location("multipart", file_path)
+            assert spec is not None, f"{file_path} found but not loadable!"
+            module = importlib.util.module_from_spec(spec)
+            sys.modules["multipart"] = module
+            assert spec.loader is not None, f"{file_path} must be loadable!"
+            spec.loader.exec_module(module)
+            break
+    except PermissionError:
+        pass
 else:
     warnings.warn("Please use `import python_multipart` instead.", PendingDeprecationWarning, stacklevel=2)
     from python_multipart import *


### PR DESCRIPTION
Path.is_file() throws PermissionError if the current user is not allowed to list one of the parent directories. An import would also fail, so treat this as if the file wasn't there.

fixes #181