### PR TITLE
fuzz: Add cifuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -15,6 +15,7 @@ on:
 permissions: {}
 
 jobs:
+  # https://google.github.io/oss-fuzz/getting-started/continuous-integration/
   Fuzzing:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This PR adds [cifuzz](https://google.github.io/oss-fuzz/getting-started/continuous-integration/) action workflow which is a service provided by oss-fuzz where this project already runs, this helps in catching shallow bugs, regression or build breakage by running fuzzers on PR for ~5 minutes (excluding the build time) on 'release/**' branch..