### PR TITLE
Add Dependabot cooldown for pip and github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       python-packages:
         patterns:
@@ -12,6 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary
- Adds a 7-day `cooldown.default-days` to both the `pip` and `github-actions` Dependabot updaters.
- Resolves zizmor `dependabot-cooldown` findings reported as code scanning alerts #1 and #2.
- Mitigates opportunistic supply-chain compromises by delaying adoption of freshly released versions.

## Test plan
- [x] `zizmor .github/dependabot.yml` reports no findings locally.