### PR TITLE
Test against Python 3.15 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary
- Add Python 3.15 to the CI test matrix in `.github/workflows/main.yml`.
- `uv` pulls Python from `python-build-standalone`, which currently ships `3.15.0a8`, so `setup-uv` will install the alpha automatically when the version is requested explicitly.

## Test plan
- [x] CI run on this PR completes the 3.15 job successfully.