### PR TITLE
Handle multipart headers case-insensitively

### DIFF
--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -1673,7 +1673,7 @@ class FormParser:
                 header_value.append(data[start:end])
 
             def on_header_end() -> None:
-                headers[b"".join(header_name)] = b"".join(header_value)
+                headers[b"".join(header_name).lower()] = b"".join(header_value)
                 del header_name[:]
                 del header_value[:]
 
@@ -1683,8 +1683,7 @@ class FormParser:
                 is_file = False
 
                 # Parse the content-disposition header.
-                # TODO: handle mixed case
-                content_disp = headers.get(b"Content-Disposition")
+                content_disp = headers.get(b"content-disposition")
                 disp, options = parse_options_header(content_disp)
 
                 # Get the field and filename.
@@ -1702,7 +1701,7 @@ class FormParser:
                 # Parse the given Content-Transfer-Encoding to determine what
                 # we need to do with the incoming data.
                 # TODO: check that we properly handle 8bit / 7bit encoding.
-                transfer_encoding = headers.get(b"Content-Transfer-Encoding", b"7bit")
+                transfer_encoding = headers.get(b"content-transfer-encoding", b"7bit")
 
                 if transfer_encoding in (b"binary", b"8bit", b"7bit"):
                     writer = f_multi

--- a/tests/test_data/http/mixed_case_headers.http
+++ b/tests/test_data/http/mixed_case_headers.http
@@ -1,0 +1,19 @@
+----boundary
+ConTenT-TypE: text/plain; charset="UTF-8"
+ConTenT-DisPoSitioN: form-data; name=field1
+ConTenT-TransfeR-EncoDinG: base64
+
+VGVzdCAxMjM=
+----boundary
+content-type: text/plain; charset="UTF-8"
+content-disposition: form-data; name=field2
+content-transfer-encoding: base64
+
+VGVzdCAxMjM=
+----boundary
+CONTENT-TYPE: text/plain; charset="UTF-8"
+CONTENT-DISPOSITION: form-data; name=Field3
+CONTENT-TRANSFER-ENCODING: base64
+
+VGVzdCAxMjM=
+----boundary--

--- a/tests/test_data/http/mixed_case_headers.yaml
+++ b/tests/test_data/http/mixed_case_headers.yaml
@@ -1,0 +1,14 @@
+boundary: --boundary
+expected:
+  - name: field1
+    type: field
+    data: !!binary |
+      VGVzdCAxMjM=
+  - name: field2
+    type: field
+    data: !!binary |
+      VGVzdCAxMjM=
+  - name: Field3
+    type: field
+    data: !!binary |
+      VGVzdCAxMjM=


### PR DESCRIPTION
Normalize multipart part header names to lower-case bytes before storing them internally, then look up `content-disposition` and `content-transfer-encoding` using lower-case keys.

This keeps the parser aligned with MIME multipart behavior and matches the approach used by Django for multipart part headers. It avoids converting header names to strings or title-casing them.

---

- Closes https://github.com/Kludex/python-multipart/pull/190
- Closes https://github.com/Kludex/python-multipart/issues/165