### PR TITLE
Match README and docs badges to starlette/uvicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # [Python-Multipart](https://kludex.github.io/python-multipart/)
 
+[![Build Status](https://github.com/Kludex/python-multipart/workflows/CI/badge.svg)](https://github.com/Kludex/python-multipart/actions)
 [![Package version](https://badge.fury.io/py/python-multipart.svg)](https://pypi.python.org/pypi/python-multipart)
 [![Supported Python Version](https://img.shields.io/pypi/pyversions/python-multipart.svg?color=%2334D058)](https://pypi.org/project/python-multipart)
+[![Discord](https://img.shields.io/discord/1051468649518616576?logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/RxKUF5JuHs)
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,20 @@
 # Python-Multipart
 
+<p align="center">
+<a href="https://github.com/Kludex/python-multipart/actions">
+    <img src="https://github.com/Kludex/python-multipart/workflows/CI/badge.svg" alt="Build Status">
+</a>
+<a href="https://pypi.org/project/python-multipart/">
+    <img src="https://badge.fury.io/py/python-multipart.svg" alt="Package version">
+</a>
+<a href="https://pypi.org/project/python-multipart" target="_blank">
+    <img src="https://img.shields.io/pypi/pyversions/python-multipart.svg?color=%2334D058" alt="Supported Python versions">
+</a>
+<a href="https://discord.gg/RxKUF5JuHs">
+    <img src="https://img.shields.io/discord/1051468649518616576?logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2" alt="Discord">
+</a>
+</p>
+
 Python-Multipart is a streaming multipart parser for Python.
 
 ## Quickstart


### PR DESCRIPTION
## Summary

- Add Build Status and Discord badges to `README.md` to match the set used by starlette/uvicorn.
- Add the same 4-badge row (Build Status, Package version, Supported Python versions, Discord) to `docs/index.md`, using the HTML-anchor style from starlette's docs.

## Test plan

- [ ] Badges render on GitHub in the README.
- [ ] Badges render on the mkdocs site homepage.