### PR TITLE
Ignore local Claude state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-# Claude local state
+# Local coding agents
 .claude/settings.local.json
 .claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Claude local state
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## Summary

- Ignore `.claude/worktrees/` so local Claude worktree files are not picked up by Git or source distribution checks.
- Ignore `.claude/settings.local.json` while leaving `.claude/settings.json` trackable for shared settings.

## Checks

- `git check-ignore -v .claude/settings.local.json .claude/worktrees/hashed-prancing-alpaca/README.md`
- `git check-ignore -v .claude/settings.json`