### PR TITLE
Inline oss-fuzz patches into fuzz harness

### DIFF
--- a/fuzz/fuzz_form.py
+++ b/fuzz/fuzz_form.py
@@ -29,7 +29,7 @@ def parse_form_urlencoded(fdp: EnhancedDataProvider) -> None:
 
 
 def parse_multipart_form_data(fdp: EnhancedDataProvider) -> None:
-    boundary = "boundary"
+    boundary = fdp.ConsumeRandomStringOfSize(16) or "boundary"
     header = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
     body = (
         f"--{boundary}\r\n"

--- a/fuzz/helpers.py
+++ b/fuzz/helpers.py
@@ -1,9 +1,11 @@
 import atheris
 
-
 class EnhancedDataProvider(atheris.FuzzedDataProvider):
     def ConsumeRandomBytes(self) -> bytes:
         return self.ConsumeBytes(self.ConsumeIntInRange(0, self.remaining_bytes()))
 
     def ConsumeRandomString(self) -> str:
         return self.ConsumeUnicodeNoSurrogates(self.ConsumeIntInRange(0, self.remaining_bytes()))
+
+    def ConsumeRandomStringOfSize(self, val: int) -> str:
+        return self.ConsumeUnicodeNoSurrogates(self.ConsumeIntInRange(0, val))


### PR DESCRIPTION
## Summary

- CIFuzz has been failing since #186 landed because `build.sh` in `google/oss-fuzz/projects/python-multipart` runs `git apply $SRC/python-multipart/*.patch`, but CIFuzz re-materializes `$SRC/python-multipart` with the tested commit after the Dockerfile `COPY *.patch` step, wiping the two patch files before `git apply` runs. Regular OSS-Fuzz builds don't do that, so the breakage only shows up in CIFuzz.
- Inlines the two upstream patches (`fuzz_form.patch`, `helpers.patch`) directly into `fuzz/helpers.py` and `fuzz/fuzz_form.py`. This also improves coverage by randomizing the multipart boundary.
- Companion cleanup on the oss-fuzz side (remove patches, drop `COPY *.patch` and `git apply`) will be opened as a follow-up PR.

Failing run: https://github.com/Kludex/python-multipart/actions/runs/24236427415/job/70760049062

## Test plan

- [ ] CIFuzz `Build Fuzzers` step succeeds on this branch
- [ ] `Run Fuzzers` step completes without regressions