### PR TITLE
Remove custom FormParser classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,17 +111,9 @@ omit = ["tests/*"]
 fail_under = 100
 skip_covered = true
 show_missing = true
-exclude_lines = [
-    "pragma: no cover",
-    "raise NotImplementedError",
-    "def __str__",
+exclude_also = [
     "def __repr__",
-    "if 0:",
-    "if False:",
     "if __name__ == .__main__.:",
-    "if self\\.config\\['DEBUG'\\]:",
-    "if self\\.debug:",
-    "except ImportError:",
 ]
 
 [tool.check-sdist]

--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -9,14 +9,14 @@ from email.message import Message
 from enum import IntEnum
 from io import BufferedRandom, BytesIO
 from numbers import Number
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast, overload
 
 from .decoders import Base64Decoder, QuotedPrintableDecoder
 from .exceptions import FileError, FormParserError, MultipartParseError, QuerystringParseError
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from collections.abc import Callable
-    from typing import Any, Literal, Protocol, TypeAlias, TypedDict
+    from typing import Any, Literal, Protocol, TypeAlias, TypedDict, TypeVar
 
     class SupportsRead(Protocol):
         def read(self, __n: int) -> bytes: ...
@@ -70,8 +70,8 @@ if TYPE_CHECKING:  # pragma: no cover
     class FileProtocol(_FormProtocol, Protocol):
         def __init__(self, file_name: bytes | None, field_name: bytes | None, config: FileConfig) -> None: ...
 
-    OnFieldCallback = Callable[[FieldProtocol], None]
-    OnFileCallback = Callable[[FileProtocol], None]
+    FieldT = TypeVar("FieldT", bound=FieldProtocol)
+    FileT = TypeVar("FileT", bound=FileProtocol)
 
     CallbackName: TypeAlias = Literal[
         "start",
@@ -1513,11 +1513,40 @@ class FormParser:
         "UPLOAD_ERROR_ON_BAD_CTE": False,
     }
 
+    @overload
     def __init__(
         self,
         content_type: str,
-        on_field: OnFieldCallback | None,
-        on_file: OnFileCallback | None,
+        on_field: Callable[[Field], None] | None,
+        on_file: Callable[[File], None] | None,
+        on_end: Callable[[], None] | None = None,
+        boundary: bytes | str | None = None,
+        file_name: bytes | None = None,
+        FileClass: type[File] = File,
+        FieldClass: type[Field] = Field,
+        config: dict[Any, Any] = {},
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        content_type: str,
+        on_field: Callable[[FieldT], None] | None,
+        on_file: Callable[[FileT], None] | None,
+        on_end: Callable[[], None] | None = None,
+        boundary: bytes | str | None = None,
+        file_name: bytes | None = None,
+        *,
+        FileClass: type[FileT],
+        FieldClass: type[FieldT],
+        config: dict[Any, Any] = {},
+    ) -> None: ...
+
+    def __init__(
+        self,
+        content_type: str,
+        on_field: Callable[..., None] | None,
+        on_file: Callable[..., None] | None,
         on_end: Callable[[], None] | None = None,
         boundary: bytes | str | None = None,
         file_name: bytes | None = None,
@@ -1778,8 +1807,8 @@ class FormParser:
 
 def create_form_parser(
     headers: dict[str, bytes],
-    on_field: OnFieldCallback | None,
-    on_file: OnFileCallback | None,
+    on_field: Callable[[Field], None] | None,
+    on_file: Callable[[File], None] | None,
     config: dict[Any, Any] = {},
 ) -> FormParser:
     """This function is a helper function to aid in creating a FormParser
@@ -1817,8 +1846,8 @@ def create_form_parser(
 def parse_form(
     headers: dict[str, bytes],
     input_stream: SupportsRead,
-    on_field: OnFieldCallback | None,
-    on_file: OnFileCallback | None,
+    on_field: Callable[[Field], None] | None,
+    on_file: Callable[[File], None] | None,
     chunk_size: int = 1048576,
 ) -> None:
     """This function is useful if you just want to parse a request body,

--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -9,14 +9,14 @@ from email.message import Message
 from enum import IntEnum
 from io import BufferedRandom, BytesIO
 from numbers import Number
-from typing import TYPE_CHECKING, cast, overload
+from typing import TYPE_CHECKING, cast
 
 from .decoders import Base64Decoder, QuotedPrintableDecoder
 from .exceptions import FileError, FormParserError, MultipartParseError, QuerystringParseError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from typing import Any, Literal, Protocol, TypeAlias, TypedDict, TypeVar
+    from typing import Any, Literal, Protocol, TypeAlias, TypedDict
 
     class SupportsRead(Protocol):
         def read(self, __n: int) -> bytes: ...
@@ -54,24 +54,6 @@ if TYPE_CHECKING:
     class FormParserConfig(FileConfig):
         UPLOAD_ERROR_ON_BAD_CTE: bool
         MAX_BODY_SIZE: float
-
-    class _FormProtocol(Protocol):
-        def write(self, data: bytes) -> int: ...
-
-        def finalize(self) -> None: ...
-
-        def close(self) -> None: ...
-
-    class FieldProtocol(_FormProtocol, Protocol):
-        def __init__(self, name: bytes | None) -> None: ...
-
-        def set_none(self) -> None: ...
-
-    class FileProtocol(_FormProtocol, Protocol):
-        def __init__(self, file_name: bytes | None, field_name: bytes | None, config: FileConfig) -> None: ...
-
-    FieldT = TypeVar("FieldT", bound=FieldProtocol)
-    FileT = TypeVar("FileT", bound=FileProtocol)
 
     CallbackName: TypeAlias = Literal[
         "start",
@@ -1483,19 +1465,6 @@ class FormParser:
         file_name: If the request is of type application/octet-stream, then the body of the request will not contain any
             information about the uploaded file.  In such cases, you can provide the file name of the uploaded file
             manually.
-        FileClass: The class to use for uploaded files.  Defaults to :class:`File`, but you can provide your own class
-            if you wish to customize behaviour.  The class will be instantiated as
-            FileClass(file_name, field_name, config=config), and it must provide the following functions::
-                - file_instance.write(data)
-                - file_instance.finalize()
-                - file_instance.close()
-        FieldClass: The class to use for uploaded fields.  Defaults to :class:`Field`, but you can provide your own
-            class if you wish to customize behaviour.  The class will be instantiated as FieldClass(field_name), and it
-            must provide the following functions::
-                - field_instance.write(data)
-                - field_instance.finalize()
-                - field_instance.close()
-                - field_instance.set_none()
         config: Configuration to use for this FormParser.  The default values are taken from the DEFAULT_CONFIG value,
             and then any keys present in this dictionary will overwrite the default values.
     """
@@ -1513,7 +1482,6 @@ class FormParser:
         "UPLOAD_ERROR_ON_BAD_CTE": False,
     }
 
-    @overload
     def __init__(
         self,
         content_type: str,
@@ -1522,36 +1490,6 @@ class FormParser:
         on_end: Callable[[], None] | None = None,
         boundary: bytes | str | None = None,
         file_name: bytes | None = None,
-        FileClass: type[File] = File,
-        FieldClass: type[Field] = Field,
-        config: dict[Any, Any] = {},
-    ) -> None: ...
-
-    @overload
-    def __init__(
-        self,
-        content_type: str,
-        on_field: Callable[[FieldT], None] | None,
-        on_file: Callable[[FileT], None] | None,
-        on_end: Callable[[], None] | None = None,
-        boundary: bytes | str | None = None,
-        file_name: bytes | None = None,
-        *,
-        FileClass: type[FileT],
-        FieldClass: type[FieldT],
-        config: dict[Any, Any] = {},
-    ) -> None: ...
-
-    def __init__(
-        self,
-        content_type: str,
-        on_field: Callable[..., None] | None,
-        on_file: Callable[..., None] | None,
-        on_end: Callable[[], None] | None = None,
-        boundary: bytes | str | None = None,
-        file_name: bytes | None = None,
-        FileClass: type[FileProtocol] = File,
-        FieldClass: type[FieldProtocol] = Field,
         config: dict[Any, Any] = {},
     ) -> None:
         self.logger = logging.getLogger(__name__)
@@ -1567,10 +1505,6 @@ class FormParser:
         self.on_file = on_file
         self.on_end = on_end
 
-        # Save classes.
-        self.FileClass = File
-        self.FieldClass = Field
-
         # Set configuration options.
         self.config: FormParserConfig = self.DEFAULT_CONFIG.copy()
         self.config.update(config)  # type: ignore[typeddict-item]
@@ -1579,18 +1513,20 @@ class FormParser:
 
         # Depending on the Content-Type, we instantiate the correct parser.
         if content_type == "application/octet-stream":
-            file: FileProtocol = None  # type: ignore
+            file: File | None = None
 
             def on_start() -> None:
                 nonlocal file
-                file = FileClass(file_name, None, config=self.config)
+                file = File(file_name, None, config=self.config)
 
             def on_data(data: bytes, start: int, end: int) -> None:
                 nonlocal file
+                assert file is not None
                 file.write(data[start:end])
 
             def _on_end() -> None:
                 nonlocal file
+                assert file is not None
                 # Finalize the file itself.
                 file.finalize()
 
@@ -1611,7 +1547,7 @@ class FormParser:
         elif content_type == "application/x-www-form-urlencoded" or content_type == "application/x-url-encoded":
             name_buffer: list[bytes] = []
 
-            f: FieldProtocol | None = None
+            f: Field | None = None
 
             def on_field_start() -> None:
                 pass
@@ -1622,7 +1558,7 @@ class FormParser:
             def on_field_data(data: bytes, start: int, end: int) -> None:
                 nonlocal f
                 if f is None:
-                    f = FieldClass(b"".join(name_buffer))
+                    f = Field(b"".join(name_buffer))
                     del name_buffer[:]
                 f.write(data[start:end])
 
@@ -1632,7 +1568,7 @@ class FormParser:
                 if f is None:
                     # If we get here, it's because there was no field data.
                     # We create a field, set it to None, and then continue.
-                    f = FieldClass(b"".join(name_buffer))
+                    f = Field(b"".join(name_buffer))
                     del name_buffer[:]
                     f.set_none()
 
@@ -1666,8 +1602,8 @@ class FormParser:
             header_value: list[bytes] = []
             headers: dict[bytes, bytes] = {}
 
-            f_multi: FileProtocol | FieldProtocol | None = None
-            writer = None
+            f_multi: File | Field | None = None
+            writer: File | Field | Base64Decoder | QuotedPrintableDecoder | None = None
             is_file = False
 
             def on_part_begin() -> None:
@@ -1687,10 +1623,12 @@ class FormParser:
                 f_multi.finalize()
                 if is_file:
                     if on_file:
+                        assert isinstance(f_multi, File)
                         on_file(f_multi)
                 else:
                     if on_field:
-                        on_field(cast("FieldProtocol", f_multi))
+                        assert isinstance(f_multi, Field)
+                        on_field(f_multi)
 
             def on_header_field(data: bytes, start: int, end: int) -> None:
                 header_name.append(data[start:end])
@@ -1719,9 +1657,9 @@ class FormParser:
 
                 # Create the proper class.
                 if file_name is None:
-                    f_multi = FieldClass(field_name)
+                    f_multi = Field(field_name)
                 else:
-                    f_multi = FileClass(file_name, field_name, config=self.config)
+                    f_multi = File(file_name, field_name, config=self.config)
                     is_file = True
 
                 # Parse the given Content-Transfer-Encoding to determine what

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1432,12 +1432,12 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertEqual(on_file.call_args[0][0].size, 15)
 
     def test_parse_form_content_length(self) -> None:
-        files: list[FileProtocol] = []
+        files: list[File] = []
 
-        def on_field(field: FieldProtocol) -> None:
+        def on_field(field: Field) -> None:
             pass
 
-        def on_file(file: FileProtocol) -> None:
+        def on_file(file: File) -> None:
             files.append(file)
 
         parse_form(
@@ -1448,7 +1448,7 @@ class TestHelperFunctions(unittest.TestCase):
         )
 
         self.assertEqual(len(files), 1)
-        self.assertEqual(files[0].size, 10)  # type: ignore[attr-defined]
+        self.assertEqual(files[0].size, 10)
 
     def test_parse_form_invalid_chunk_size(self) -> None:
         with self.assertRaisesRegex(ValueError, "chunk_size must be a positive number, not 0"):

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 import unittest
 from io import BytesIO
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from typing import Any, TypedDict
 
-    from python_multipart.multipart import FieldProtocol, FileConfig, FileProtocol
+    from python_multipart.multipart import FileConfig
 
     class TestParams(TypedDict):
         name: str
@@ -753,11 +753,11 @@ class TestFormParser(unittest.TestCase):
         self.files: list[File] = []
         self.fields: list[Field] = []
 
-        def on_field(f: FieldProtocol) -> None:
-            self.fields.append(cast(Field, f))
+        def on_field(f: Field) -> None:
+            self.fields.append(f)
 
-        def on_file(f: FileProtocol) -> None:
-            self.files.append(cast(File, f))
+        def on_file(f: File) -> None:
+            self.files.append(f)
 
         def on_end() -> None:
             self.ended = True
@@ -1115,8 +1115,8 @@ class TestFormParser(unittest.TestCase):
     def test_octet_stream(self) -> None:
         files: list[File] = []
 
-        def on_file(f: FileProtocol) -> None:
-            files.append(cast(File, f))
+        def on_file(f: File) -> None:
+            files.append(f)
 
         on_field = Mock()
         on_end = Mock()
@@ -1137,8 +1137,8 @@ class TestFormParser(unittest.TestCase):
     def test_querystring(self) -> None:
         fields: list[Field] = []
 
-        def on_field(f: FieldProtocol) -> None:
-            fields.append(cast(Field, f))
+        def on_field(f: Field) -> None:
+            fields.append(f)
 
         on_file = Mock()
         on_end = Mock()
@@ -1208,8 +1208,8 @@ class TestFormParser(unittest.TestCase):
 
         files: list[File] = []
 
-        def on_file(f: FileProtocol) -> None:
-            files.append(cast(File, f))
+        def on_file(f: File) -> None:
+            files.append(f)
 
         on_field = Mock()
         on_end = Mock()
@@ -1233,8 +1233,8 @@ class TestFormParser(unittest.TestCase):
     def test_handles_None_fields(self) -> None:
         fields: list[Field] = []
 
-        def on_field(f: FieldProtocol) -> None:
-            fields.append(cast(Field, f))
+        def on_field(f: Field) -> None:
+            fields.append(f)
 
         on_file = Mock()
         on_end = Mock()
@@ -1265,8 +1265,8 @@ class TestFormParser(unittest.TestCase):
 
         files: list[File] = []
 
-        def on_file(f: FileProtocol) -> None:
-            files.append(cast(File, f))
+        def on_file(f: File) -> None:
+            files.append(f)
 
         f = FormParser("multipart/form-data", on_field=Mock(), on_file=on_file, boundary="boundary")
         f.write(data.encode("latin-1"))
@@ -1284,8 +1284,8 @@ class TestFormParser(unittest.TestCase):
 
         files: list[File] = []
 
-        def on_file(f: FileProtocol) -> None:
-            files.append(cast(File, f))
+        def on_file(f: File) -> None:
+            files.append(f)
 
         f = FormParser("multipart/form-data", on_field=Mock(), on_file=on_file, boundary="boundary")
         f.write(data.encode("latin-1"))
@@ -1306,8 +1306,8 @@ class TestFormParser(unittest.TestCase):
 
         files: list[File] = []
 
-        def on_file(f: FileProtocol) -> None:
-            files.append(cast(File, f))
+        def on_file(f: File) -> None:
+            files.append(f)
 
         f = FormParser("multipart/form-data", on_field=Mock(), on_file=on_file, boundary="boundary")
         with self._caplog.at_level(logging.WARNING):
@@ -1354,8 +1354,8 @@ class TestFormParser(unittest.TestCase):
     def test_octet_stream_max_size(self) -> None:
         files: list[File] = []
 
-        def on_file(f: FileProtocol) -> None:
-            files.append(cast(File, f))
+        def on_file(f: File) -> None:
+            files.append(f)
 
         on_field = Mock()
         on_end = Mock()


### PR DESCRIPTION
## Summary

Removes the `FileClass` and `FieldClass` parameters from `FormParser`. The parser now consistently constructs the built-in `File` and `Field` classes, and callback annotations are concrete accordingly.

Also updates the coverage configuration to use `exclude_also` with the reduced exclusion list.

## Validation

- `.venv/bin/mypy python_multipart multipart tests`
- `.venv/bin/pytest tests/test_multipart.py -q`
- `.venv/bin/ruff check python_multipart/multipart.py tests/test_multipart.py`
- `.venv/bin/ruff format --check --diff python_multipart/multipart.py tests/test_multipart.py`