### PR TITLE
Handle CTE values case-insensitively

### DIFF
--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -1665,7 +1665,9 @@ class FormParser:
                 # Parse the given Content-Transfer-Encoding to determine what
                 # we need to do with the incoming data.
                 # TODO: check that we properly handle 8bit / 7bit encoding.
-                transfer_encoding = headers.get(b"content-transfer-encoding", b"7bit")
+                # RFC 2045 section 6.1: Content-Transfer-Encoding values are case-insensitive.
+                # https://www.rfc-editor.org/rfc/rfc2045#section-6.1
+                transfer_encoding = headers.get(b"content-transfer-encoding", b"7bit").lower()
 
                 if transfer_encoding in (b"binary", b"8bit", b"7bit"):
                     writer = f_multi

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -746,6 +746,25 @@ def split_all(val: bytes) -> Iterator[tuple[bytes, bytes]]:
         yield (val[:i], val[i:])
 
 
+@pytest.mark.parametrize("content_transfer_encoding", [b"base64", b"BASE64", b"Base64"])
+def test_content_transfer_encoding_is_case_insensitive(content_transfer_encoding: bytes) -> None:
+    data = (
+        b'----boundary\r\nContent-Disposition: form-data; name="file"; filename="test.txt"\r\n'
+        b"Content-Type: text/plain\r\n"
+        b"Content-Transfer-Encoding: " + content_transfer_encoding + b"\r\n\r\nVGVzdA==\r\n----boundary--\r\n"
+    )
+    files: list[File] = []
+
+    f = FormParser("multipart/form-data", None, files.append, boundary="--boundary")
+
+    f.write(data)
+    f.finalize()
+
+    file = files[0]
+    file.file_object.seek(0)
+    assert file.file_object.read() == b"Test"
+
+
 @parametrize_class
 class TestFormParser(unittest.TestCase):
     def make(self, boundary: str | bytes, config: dict[str, Any] = {}) -> None:


### PR DESCRIPTION
## Summary
- normalize Content-Transfer-Encoding values before comparing supported encodings
- cite RFC 2045 section 6.1 next to the normalization
- add pytest-parametrized regression coverage for lowercase, uppercase, and mixed-case base64 values

## Tests
- uv run pytest tests/test_multipart.py::test_content_transfer_encoding_is_case_insensitive -q
- uv run pytest tests/test_multipart.py -q
- uv run ruff check .