### PR TITLE
Skip multipart preamble bytes before the first boundary

### DIFF
--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -1172,23 +1172,28 @@ class MultipartParser(BaseParser):
 
             elif state == MultipartState.PREAMBLE:
                 # Preamble: bytes before the first boundary delimiter.  Per
-                # RFC 2046 section 5.1.1, these must be ignored.  We scan
-                # forward for the boundary, taking care to handle the case
-                # where a partial match spans chunk boundaries.
+                # RFC 2046 section 5.1.1, these must be ignored.  A candidate
+                # match is only a real delimiter when followed by CRLF (new
+                # part) or "--" (close boundary); anything else is preamble
+                # text that happens to contain the boundary value and must
+                # be skipped without erroring.
+                #
+                # `index` encodes the match sub-phase:
+                #   0 .. boundary_length - 1  -> matching boundary bytes
+                #   boundary_length           -> verifying trailer byte
+                #   boundary_length + 1       -> expecting LF after CR
+                #   boundary_length + 2       -> expecting HYPHEN after HYPHEN
                 boundary_length = len(boundary)
 
-                # Fast path: try to locate the full boundary in the current
-                # buffer.  `index` carries over a partial match from a
-                # previous chunk, so only use find when we don't have one.
+                # Fast path: when we don't have a partial match carried over
+                # from a previous chunk, search the whole buffer at once.
                 if index == 0:
                     i0 = data.find(boundary, i, length)
                     if i0 >= 0:
-                        # Found the full boundary.  Hand off to START_BOUNDARY
-                        # positioned to validate the trailing bytes (either
-                        # CRLF for a new part, or "--" for an empty message).
+                        # Jump past the match and enter trailer verification
+                        # on the byte immediately after the boundary.
                         i = i0 + boundary_length
-                        index = boundary_length - 2
-                        state = MultipartState.START_BOUNDARY
+                        index = boundary_length
                         continue
 
                     # No full match; there may be a partial match at the end
@@ -1201,21 +1206,45 @@ class MultipartParser(BaseParser):
                         break
                     c = data[i]
 
-                # Byte-by-byte matching for a partial boundary that may span
-                # chunks.  `index` tracks how many boundary bytes have matched.
-                if boundary[index] == c:
-                    index += 1
-                    if index == boundary_length:
-                        # Completed the boundary match across chunks.  Hand
-                        # off to START_BOUNDARY to validate trailing bytes.
-                        index = boundary_length - 2
-                        state = MultipartState.START_BOUNDARY
+                if index < boundary_length:
+                    # Byte-by-byte matching of boundary bytes that may span
+                    # chunks.
+                    if boundary[index] == c:
+                        index += 1
+                    else:
+                        # Mismatch on a partial match carried over from a
+                        # prior chunk.  Discard it and reconsider the current
+                        # byte as a potential new start.
+                        index = 0
+                        i -= 1
+                elif index == boundary_length:
+                    # Trailer verification: a real boundary delimiter is
+                    # followed by CR (regular) or HYPHEN (close).
+                    if c == CR:
+                        index = boundary_length + 1
+                    elif c == HYPHEN:
+                        index = boundary_length + 2
+                    else:
+                        # False positive inside the preamble - just part of
+                        # the preamble text.  Reset and keep scanning.
+                        index = 0
+                elif index == boundary_length + 1:
+                    # Regular delimiter: expect LF after CR.
+                    if c == LF:
+                        self.callback("part_begin")
+                        index = 0
+                        state = MultipartState.HEADER_FIELD_START
+                    else:
+                        # False positive: CR not followed by LF.  Reset.
+                        index = 0
                 else:
-                    # Mismatch on a partial match carried over from a prior
-                    # chunk.  Discard it and reconsider the current byte as a
-                    # potential new start.
-                    index = 0
-                    i -= 1
+                    # Close delimiter: expect HYPHEN after HYPHEN.
+                    if c == HYPHEN:
+                        self.callback("end")
+                        state = MultipartState.END
+                    else:
+                        # False positive: HYPHEN not followed by HYPHEN.
+                        index = 0
 
             elif state == MultipartState.HEADER_FIELD_START:
                 # Mark the start of a header field here, reset the index, and

--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -109,6 +109,7 @@ class MultipartState(IntEnum):
     PART_DATA_END = 10
     END_BOUNDARY = 11
     END = 12
+    PREAMBLE = 13
 
 
 # Flags for the multipart parser.
@@ -1111,9 +1112,16 @@ class MultipartParser(BaseParser):
                 # index is used as in index into our boundary.  Set to 0.
                 index = 0
 
-                # Move to the next state, but decrement i so that we re-process
-                # this character.
-                state = MultipartState.START_BOUNDARY
+                # If the first non-CRLF byte is a hyphen, assume the boundary
+                # starts here and validate it via START_BOUNDARY.  Otherwise,
+                # we're looking at a preamble (RFC 2046 section 5.1.1): bytes
+                # before the first boundary delimiter that must be ignored.
+                if c == HYPHEN:
+                    state = MultipartState.START_BOUNDARY
+                else:
+                    state = MultipartState.PREAMBLE
+
+                # Re-process this character under the new state.
                 i -= 1
 
             elif state == MultipartState.START_BOUNDARY:
@@ -1161,6 +1169,53 @@ class MultipartParser(BaseParser):
 
                     # Increment index into boundary and continue.
                     index += 1
+
+            elif state == MultipartState.PREAMBLE:
+                # Preamble: bytes before the first boundary delimiter.  Per
+                # RFC 2046 section 5.1.1, these must be ignored.  We scan
+                # forward for the boundary, taking care to handle the case
+                # where a partial match spans chunk boundaries.
+                boundary_length = len(boundary)
+
+                # Fast path: try to locate the full boundary in the current
+                # buffer.  `index` carries over a partial match from a
+                # previous chunk, so only use find when we don't have one.
+                if index == 0:
+                    i0 = data.find(boundary, i, length)
+                    if i0 >= 0:
+                        # Found the full boundary.  Hand off to START_BOUNDARY
+                        # positioned to validate the trailing bytes (either
+                        # CRLF for a new part, or "--" for an empty message).
+                        i = i0 + boundary_length
+                        index = boundary_length - 2
+                        state = MultipartState.START_BOUNDARY
+                        continue
+
+                    # No full match; there may be a partial match at the end
+                    # of the buffer.  Skip ahead to the last position where a
+                    # boundary could still start.
+                    i = max(i, length - boundary_length)
+                    while i < length and data[i] != boundary[0]:
+                        i += 1
+                    if i >= length:
+                        break
+                    c = data[i]
+
+                # Byte-by-byte matching for a partial boundary that may span
+                # chunks.  `index` tracks how many boundary bytes have matched.
+                if boundary[index] == c:
+                    index += 1
+                    if index == boundary_length:
+                        # Completed the boundary match across chunks.  Hand
+                        # off to START_BOUNDARY to validate trailing bytes.
+                        index = boundary_length - 2
+                        state = MultipartState.START_BOUNDARY
+                else:
+                    # Mismatch on a partial match carried over from a prior
+                    # chunk.  Discard it and reconsider the current byte as a
+                    # potential new start.
+                    index = 0
+                    i -= 1
 
             elif state == MultipartState.HEADER_FIELD_START:
                 # Mark the start of a header field here, reset the index, and
@@ -1461,9 +1516,16 @@ class MultipartParser(BaseParser):
         are in the final state of the parser (i.e. the end of the multipart
         message is well-formed), and, if not, throw an error.
         """
+        # If we are still scanning the preamble, no boundary was ever found -
+        # which means the input is not a valid multipart message.
+        if self.state == MultipartState.PREAMBLE:
+            msg = "No boundary found in multipart body"
+            self.logger.warning(msg)
+            e = MultipartParseError(msg)
+            e.offset = 0
+            raise e
         # TODO: verify that we're in the state MultipartState.END, otherwise throw an
         # error or otherwise state that we're not finished parsing.
-        pass
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(boundary={self.boundary!r})"

--- a/tests/test_data/http/preamble.http
+++ b/tests/test_data/http/preamble.http
@@ -1,0 +1,6 @@
+This is a multipart message.
+--boundary
+Content-Disposition: form-data; name="field"
+
+test1
+--boundary--

--- a/tests/test_data/http/preamble.yaml
+++ b/tests/test_data/http/preamble.yaml
@@ -1,0 +1,6 @@
+boundary: boundary
+expected:
+  - name: field
+    type: field
+    data: !!binary |
+      dGVzdDE=

--- a/tests/test_data/http/preamble_mime_headers.http
+++ b/tests/test_data/http/preamble_mime_headers.http
@@ -1,0 +1,8 @@
+MIME-Version: 1.0
+Content-Type: multipart/form-data; boundary="boundary"
+
+--boundary
+Content-Disposition: form-data; name="field"
+
+test1
+--boundary--

--- a/tests/test_data/http/preamble_mime_headers.yaml
+++ b/tests/test_data/http/preamble_mime_headers.yaml
@@ -1,0 +1,6 @@
+boundary: boundary
+expected:
+  - name: field
+    type: field
+    data: !!binary |
+      dGVzdDE=

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -732,6 +732,8 @@ single_byte_tests = [
     "almost_match_boundary_without_LF",
     "almost_match_boundary_without_final_hyphen",
     "single_field_single_file",
+    "preamble",
+    "preamble_mime_headers",
 ]
 
 
@@ -1174,6 +1176,50 @@ class TestFormParser(unittest.TestCase):
             MultipartParseError, "Expected boundary character {!r}, got {!r}".format(b"b"[0], b"B"[0])
         ):
             self.f.write(data)
+
+    def test_preamble_is_ignored(self) -> None:
+        # RFC 2046 section 5.1.1: bytes before the first boundary delimiter
+        # must be ignored.  This covers machine-generated payloads that
+        # include MIME-style headers before the first boundary.
+        self.make("boundary")
+        data = (
+            b"MIME-Version: 1.0\r\n"
+            b'Content-Type: multipart/form-data; boundary="boundary"\r\n'
+            b"\r\n"
+            b"--boundary\r\n"
+            b'Content-Disposition: form-data; name="field"\r\n'
+            b"\r\n"
+            b"value\r\n"
+            b"--boundary--\r\n"
+        )
+        self.f.write(data)
+        self.f.finalize()
+        self.assert_field(b"field", b"value")
+
+    def test_preamble_split_across_writes(self) -> None:
+        # The boundary can straddle chunk boundaries - exercise the
+        # byte-by-byte partial-match path in the PREAMBLE state.
+        self.make("boundary")
+        data = (
+            b"preamble text\r\n"
+            b"--boundary\r\n"
+            b'Content-Disposition: form-data; name="field"\r\n'
+            b"\r\n"
+            b"value\r\n"
+            b"--boundary--\r\n"
+        )
+        for b in data:
+            self.f.write(bytes([b]))
+        self.f.finalize()
+        self.assert_field(b"field", b"value")
+
+    def test_finalize_raises_when_no_boundary_found(self) -> None:
+        # Input that never contains a boundary must still raise, otherwise
+        # malformed bodies would be silently accepted as empty.
+        self.make("boundary")
+        self.f.write(b"this is not a multipart body at all")
+        with self.assertRaises(MultipartParseError):
+            self.f.finalize()
 
     def test_octet_stream(self) -> None:
         files: list[File] = []

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1221,6 +1221,66 @@ class TestFormParser(unittest.TestCase):
         with self.assertRaises(MultipartParseError):
             self.f.finalize()
 
+    def test_preamble_skips_boundary_false_positive(self) -> None:
+        # A preamble line that starts with `--boundary` but is not followed
+        # by a valid delimiter trailer must be treated as preamble text,
+        # not as a delimiter that causes the parser to raise.
+        self.make("boundary")
+        data = (
+            b"preamble line one\r\n"
+            b"--boundaryX is not a real delimiter\r\n"
+            b"--boundary\r\n"
+            b'Content-Disposition: form-data; name="field"\r\n'
+            b"\r\n"
+            b"value\r\n"
+            b"--boundary--\r\n"
+        )
+        self.f.write(data)
+        self.f.finalize()
+        self.assert_field(b"field", b"value")
+
+    def test_preamble_skips_cr_without_lf_false_positive(self) -> None:
+        # `\r\n--boundary\r` followed by a non-LF byte is not a delimiter.
+        self.make("boundary")
+        data = (
+            b"preamble\r\n"
+            b"--boundary\rfoo\r\n"
+            b"--boundary\r\n"
+            b'Content-Disposition: form-data; name="field"\r\n'
+            b"\r\n"
+            b"value\r\n"
+            b"--boundary--\r\n"
+        )
+        self.f.write(data)
+        self.f.finalize()
+        self.assert_field(b"field", b"value")
+
+    def test_preamble_skips_hyphen_without_hyphen_false_positive(self) -> None:
+        # `\r\n--boundary-` followed by a non-HYPHEN byte is not a delimiter.
+        self.make("boundary")
+        data = (
+            b"preamble\r\n"
+            b"--boundary-X\r\n"
+            b"--boundary\r\n"
+            b'Content-Disposition: form-data; name="field"\r\n'
+            b"\r\n"
+            b"value\r\n"
+            b"--boundary--\r\n"
+        )
+        self.f.write(data)
+        self.f.finalize()
+        self.assert_field(b"field", b"value")
+
+    def test_preamble_followed_by_close_boundary(self) -> None:
+        # A preamble followed directly by the close boundary (empty body)
+        # should parse without error and produce no fields.
+        self.make("boundary")
+        data = b"preamble text\r\n--boundary--\r\n"
+        self.f.write(data)
+        self.f.finalize()
+        self.assertEqual(self.fields, [])
+        self.assertEqual(self.files, [])
+
     def test_octet_stream(self) -> None:
         files: list[File] = []
 


### PR DESCRIPTION
## Summary

- Add a `PREAMBLE` parser state that ignores bytes before the first boundary delimiter, per RFC 2046 section 5.1.1. Closes #59.
- Raise `MultipartParseError` in `finalize()` if no boundary was ever found, preserving the existing behavior for garbage input.
- The first non-CRLF byte determines the branch: a leading `-` still routes through `START_BOUNDARY` (unchanged), anything else enters `PREAMBLE` and scans forward for the boundary. This keeps all existing error cases (`bad_initial_boundary`, `empty_message_with_bad_end`) intact.

## Test plan

- [x] Two new HTTP fixtures (`preamble`, `preamble_mime_headers`) covering the scenario from #59 (machine-generated payload with MIME-style headers before the first boundary).
- [x] Added both fixtures to `single_byte_tests` to exercise the byte-by-byte path where the boundary straddles chunk boundaries.
- [x] `test_preamble_is_ignored`, `test_preamble_split_across_writes`, `test_finalize_raises_when_no_boundary_found`.
- [x] All 141 tests pass, 100% line coverage, ruff + mypy clean.