### PR TITLE
Version 0.0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.0.25 (2026-04-10)
+
+* Add MIME content type info to `File` [#143](https://github.com/Kludex/python-multipart/pull/143).
+* Handle CTE values case-insensitively [#258](https://github.com/Kludex/python-multipart/pull/258).
+* Remove custom `FormParser` classes [#257](https://github.com/Kludex/python-multipart/pull/257).
+* Add `UPLOAD_DELETE_TMP` to `FormParser` config [#254](https://github.com/Kludex/python-multipart/pull/254).
+* Emit `field_end` for trailing bare field names on finalize [#230](https://github.com/Kludex/python-multipart/pull/230).
+* Handle multipart headers case-insensitively [#252](https://github.com/Kludex/python-multipart/pull/252).
+
 ## 0.0.24 (2026-04-05)
 
 * Validate `chunk_size` in `parse_form()` [#244](https://github.com/Kludex/python-multipart/pull/244).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `UPLOAD_DELETE_TMP` to `FormParser` config [#254](https://github.com/Kludex/python-multipart/pull/254).
 * Emit `field_end` for trailing bare field names on finalize [#230](https://github.com/Kludex/python-multipart/pull/230).
 * Handle multipart headers case-insensitively [#252](https://github.com/Kludex/python-multipart/pull/252).
+* Apply Apache-2.0 properly [#247](https://github.com/Kludex/python-multipart/pull/247).
 
 ## 0.0.24 (2026-04-05)
 

--- a/python_multipart/__init__.py
+++ b/python_multipart/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.24"
+__version__ = "0.0.25"
 
 from .multipart import (
     BaseParser,


### PR DESCRIPTION
## Summary

- Add MIME content type info to `File` (#143).
- Handle CTE values case-insensitively (#258).
- Remove custom `FormParser` classes (#257).
- Add `UPLOAD_DELETE_TMP` to `FormParser` config (#254).
- Emit `field_end` for trailing bare field names on finalize (#230).
- Handle multipart headers case-insensitively (#252).
- Apply Apache-2.0 properly (#247).