### PR TITLE
Skip preamble before first multipart boundary

### DIFF
--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -1107,6 +1107,7 @@ class MultipartParser(BaseParser):
                 if c == CR or c == LF:
                     i = data.find(b"-", i)
                     if i == -1:
+                        # No boundary candidate in this chunk, so ignore the content after the leading CR/LF.
                         i = length
                         break
                     continue

--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -1105,7 +1105,10 @@ class MultipartParser(BaseParser):
             if state == MultipartState.START:
                 # Skip leading newlines
                 if c == CR or c == LF:
-                    i += 1
+                    i = data.find(b"-", i)
+                    if i == -1:
+                        i = length
+                        break
                     continue
 
                 # index is used as in index into our boundary.  Set to 0.

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1339,6 +1339,16 @@ class TestFormParser(unittest.TestCase):
         "chunks",
         [
             [
+                b"\r\nignored preamble\r\n"
+                + (
+                    b"--boundary\r\n"
+                    b'Content-Disposition: form-data; name="file"; filename="filename.txt"\r\n'
+                    b"Content-Type: text/plain\r\n\r\n"
+                    b"hello\r\n"
+                    b"--boundary--"
+                )
+            ],
+            [
                 b"\r\n" * 5_000_000
                 + (
                     b"--boundary\r\n"
@@ -1360,8 +1370,8 @@ class TestFormParser(unittest.TestCase):
             ],
         ],
     )
-    def test_multipart_parser_newlines_before_first_boundary(self, chunks: list[bytes]) -> None:
-        """Parser must not hang or blow up on a large preamble of blank lines before the first boundary."""
+    def test_multipart_parser_preamble_before_first_boundary(self, chunks: list[bytes]) -> None:
+        """Parser must not hang or blow up on a preamble before the first boundary."""
 
         files: list[File] = []
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1335,16 +1335,33 @@ class TestFormParser(unittest.TestCase):
         self.assertEqual(fields[2].field_name, b"baz")
         self.assertEqual(fields[2].value, b"asdf")
 
-    def test_multipart_parser_newlines_before_first_boundary(self) -> None:
-        """This test makes sure that the parser does not handle when there is junk data after the last boundary."""
-        num = 5_000_000
-        data = (
-            "\r\n" * num + "--boundary\r\n"
-            'Content-Disposition: form-data; name="file"; filename="filename.txt"\r\n'
-            "Content-Type: text/plain\r\n\r\n"
-            "hello\r\n"
-            "--boundary--"
-        )
+    @parametrize(
+        "chunks",
+        [
+            [
+                b"\r\n" * 5_000_000
+                + (
+                    b"--boundary\r\n"
+                    b'Content-Disposition: form-data; name="file"; filename="filename.txt"\r\n'
+                    b"Content-Type: text/plain\r\n\r\n"
+                    b"hello\r\n"
+                    b"--boundary--"
+                )
+            ],
+            [
+                b"\r\n" * 5_000_000,
+                (
+                    b"--boundary\r\n"
+                    b'Content-Disposition: form-data; name="file"; filename="filename.txt"\r\n'
+                    b"Content-Type: text/plain\r\n\r\n"
+                    b"hello\r\n"
+                    b"--boundary--"
+                ),
+            ],
+        ],
+    )
+    def test_multipart_parser_newlines_before_first_boundary(self, chunks: list[bytes]) -> None:
+        """Parser must not hang or blow up on a large preamble of blank lines before the first boundary."""
 
         files: list[File] = []
 
@@ -1352,7 +1369,11 @@ class TestFormParser(unittest.TestCase):
             files.append(f)
 
         f = FormParser("multipart/form-data", on_field=Mock(), on_file=on_file, boundary="boundary")
-        f.write(data.encode("latin-1"))
+        for chunk in chunks:
+            f.write(chunk)
+
+        assert len(files) == 1
+        self.assert_file_data(files[0], b"hello")
 
     def test_multipart_parser_data_after_last_boundary(self) -> None:
         """This test makes sure that the parser does not handle when there is junk data after the last boundary."""


### PR DESCRIPTION
## Summary
- skip CR/LF-prefixed preamble bytes by jumping to the next possible boundary start
- keep the existing boundary validation once a candidate boundary is reached
- avoid spending time byte-by-byte on large leading preambles before the first boundary

## Parser behavior comparison

| Parser | Bytes before first boundary |
|---|---|
| Django | Searches for the boundary and discards bytes before it as preamble. See `BoundaryIter._find_boundary()`: https://github.com/django/django/blob/main/django/http/multipartparser.py#L582-L675 |
| Werkzeug | Uses an explicit `PREAMBLE` state and regex-searches for the first boundary. See `MultipartDecoder`: https://github.com/pallets/werkzeug/blob/main/src/werkzeug/sansio/multipart.py#L98-L151 |
| multipart | The core parser rejects bytes before the first boundary unless the boundary is at offset 0 or preceded by CRLF, while the high-level non-strict helper can suppress parse errors. See `PushMultipartParser`: https://github.com/defnull/multipart/blob/master/multipart.py#L454-L487 |
| python-multipart before | Accepted leading CR/LF before the first boundary, but processed it byte-by-byte. |
| python-multipart after | Skips ahead to the next possible boundary start, preserving boundary validation from that point. |

## Benchmark
Parser-only benchmark on macOS arm64, Python 3.14.3, comparing this PR against base commit `4addb60`:

| Size | Before | After |
|---:|---:|---:|
| 1 MB | 0.087520s | 0.000052s |
| 5 MB | 0.433339s | 0.000109s |
| 10 MB | 0.861698s | 0.000186s |
| 25 MB | 2.167683s | 0.000501s |
| 50 MB | 4.356995s | 0.000903s |

Payload shape:

```python
valid = (
    b"--boundary\r\n"
    b"Content-Disposition: form-data; name=\"f\"\r\n"
    b"\r\nval\r\n"
    b"--boundary--"
)
payload = b"\r\n" * (size // 2) + valid
```

## Tests
- `uv run pytest tests/test_multipart.py -q -k "newlines_before_first_boundary or bad_start_boundary"`
- `uv run pytest tests/test_multipart.py -q`
- `uv run ruff format --check --diff python_multipart multipart tests`
- `uv run ruff check .`
