### PR TITLE
Version 0.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.26 (2026-04-10)
+
+* Skip preamble before the first multipart boundary more efficiently [#262](https://github.com/Kludex/python-multipart/pull/262).
+* Silently discard epilogue data after the closing multipart boundary [#259](https://github.com/Kludex/python-multipart/pull/259).
+
 ## 0.0.25 (2026-04-10)
 
 * Add MIME content type info to `File` [#143](https://github.com/Kludex/python-multipart/pull/143).

--- a/python_multipart/__init__.py
+++ b/python_multipart/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.25"
+__version__ = "0.0.26"
 
 from .multipart import (
     BaseParser,


### PR DESCRIPTION
## Summary
- bump version to 0.0.26
- add changelog entries for the latest multipart parser improvements

## Tests
- `uv run pytest tests/test_multipart.py -q`
- `uv run ruff format --check --diff python_multipart tests`
