### PR TITLE
Run CI on main branch pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

- update the CI workflow trigger from `master` to `main`
- ensure pull requests targeting the repository default branch run the test matrix

## Validation

- `git diff --check`
- verified `.github/workflows/main.yml` no longer references `master` in branch triggers