### PR TITLE
Version 0.0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.27 (2026-04-27)
+
+* Add multipart header limits [#267](https://github.com/Kludex/python-multipart/pull/267).
+* Pass parse offsets via constructors [#268](https://github.com/Kludex/python-multipart/pull/268).
+
 ## 0.0.26 (2026-04-10)
 
 * Skip preamble before the first multipart boundary more efficiently [#262](https://github.com/Kludex/python-multipart/pull/262).

--- a/python_multipart/__init__.py
+++ b/python_multipart/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.26"
+__version__ = "0.0.27"
 
 from .multipart import (
     BaseParser,


### PR DESCRIPTION
## Summary

- Bump version to 0.0.27.
- Update CHANGELOG with entries for #267 (multipart header limits) and #268 (pass parse offsets via constructors).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.