### PR TITLE
Speed up partial-boundary tail scan via `bytes.find`

### DIFF
--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -1332,14 +1332,12 @@ class MultipartParser(BaseParser):
                         # No match found for whole string.
                         # There may be a partial boundary at the end of the
                         # data, which the find will not match.
-                        # Since the length should to be searched is limited to
-                        # the boundary length, just perform a naive search.
+                        # Since the length to be searched is limited to the
+                        # boundary length, scan the tail for boundary[0] via
+                        # bytes.find (C-level) to keep cost off the Python loop.
                         i = max(i, data_length - boundary_length)
-
-                        # Search forward until we either hit the end of our buffer,
-                        # or reach a potential start of the boundary.
-                        while i < data_length - 1 and data[i] != boundary[0]:
-                            i += 1
+                        j = data.find(boundary[:1], i, data_length - 1)
+                        i = j if j >= 0 else data_length - 1
 
                     c = data[i]
 


### PR DESCRIPTION
## Summary
- replace the Python-level byte-by-byte while loop in the multipart partial-boundary tail scan with a single `bytes.find` call

## Why
When a chunk does not contain the full boundary, the parser falls back to scanning the trailing region for `boundary[0]`. The fallback was a Python `while` loop, which dominates parse time for non-trivial boundary lengths. Routing the same scan through `bytes.find` keeps it at C speed without changing behavior.

Measured against a 2 MB body fed in 16 KB chunks:

| Boundary length | Before | After |
| --- | --- | --- |
| 16 B    | 0.43 ms | 0.33 ms |
| 2 KB    | 12 ms   | 1.84 ms |
| 8 KB    | 43 ms   | 3.49 ms |
| 32 KB   | 92 ms   | 12.3 ms |

The post-condition of the original loop (either `data[i] == boundary[0]` or `i == data_length - 1`) is preserved exactly by the `bytes.find` replacement. All existing tests pass unchanged, including `test_random_splitting` which exhaustively exercises the partial-boundary path.

## Test plan
- [x] `pytest tests/` passes (141 tests)

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.