### PR TITLE
Switch CodSpeed benchmarks to walltime mode

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@db35df748deb45fdef0960669f57d627c1956c30 # v4.13.1
         with:
-          mode: instrumentation
+          mode: walltime
           run: uv run pytest tests/test_benchmarks.py --codspeed


### PR DESCRIPTION
## Summary
- change the CodSpeed action mode from `instrumentation` to `walltime`

## Why
Instrumentation/simulation mode runs benchmarks under valgrind and compares retired CPU instruction counts. It is deterministic and low-noise, but it misses speedups that come from reducing Python interpreter overhead.

Concretely on PR #275 (replace a Python `while` byte-loop with a single `bytes.find`), wall-clock parse time on the long-boundary scenario drops ~5x (94 ms -> 18 ms locally), but the total *retired instruction count* barely moves because the dominant cost - the C-level `bytes.find` boundary scan - is unchanged. CodSpeed reported the change as ~0.2%.

Walltime mode runs each benchmark many times on the runner and applies statistical analysis to elapsed time. It is the right tool to catch interpreter-overhead optimizations like #275.

Trade-off: walltime mode has more variance than instrumentation, so its threshold for flagging a regression is wider. That is acceptable for this codebase - we care about realistic wall-clock parsing throughput, not abstract instruction count.

Docs:
- https://docs.codspeed.io/runners/walltime/
- https://docs.codspeed.io/runners/instrumentation/

## Test plan
- [ ] CodSpeed run completes on this PR
- [ ] Re-run CodSpeed on PR #275 and verify the long-boundary speedup is now detected

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.