### PR TITLE
Revert "Switch CodSpeed benchmarks to walltime mode"

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@db35df748deb45fdef0960669f57d627c1956c30 # v4.13.1
         with:
-          mode: walltime
+          mode: instrumentation
           run: uv run pytest tests/test_benchmarks.py --codspeed


### PR DESCRIPTION
Reverts Kludex/python-multipart#278

This doesn't work. 😢 