### PR TITLE
Make the long_boundary benchmark dominated by the patched code path

### DIFF
--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -85,7 +85,7 @@ LONG_BOUNDARY_BODY = (
     + b"\r\n"
     + b'Content-Disposition: form-data; name="file"; filename="file.bin"\r\n'
     + b"Content-Type: application/octet-stream\r\n\r\n"
-    + pattern(PRINTABLE, 2 * 1024 * 1024)
+    + pattern(b"abcdefgh", 8 * 1024 * 1024)
     + b"\r\n--"
     + LONG_BOUNDARY
     + b"--\r\n"


### PR DESCRIPTION
## Summary
- change `LONG_BOUNDARY_BODY` content from `string.printable` (contains `\r`) to `b"abcdefgh"` (no `\r`)
- bump body size from 2 MiB to 8 MiB

## Why
The existing `test_multipart_long_boundary` does measure the partial-boundary fallback path, but in instrumentation mode CodSpeed reports the change from PR #275 as essentially flat. After tracing it through valgrind-equivalent instruction counting, two issues:

1. With a `string.printable` body, `\r` (the internal `boundary[0]`) appears every ~100 bytes. Each occurrence triggers the inner state-machine block which advances `index` past 0 then resets - that loop runs identically in patched and unpatched versions. It dominates the parser's instruction count and washes out the fallback delta.
2. The 2 MiB body keeps absolute fallback work below CodSpeed's noise floor.

A body without `\r` lets the parser stay in the find-miss fallback path on every chunk: the unpatched Python `while` loop scans the whole 16 KiB look-back region per chunk, while the patched `bytes.find` does the same work in C. Bumping the body to 8 MiB gives 515 chunks of that work.

Local wall-clock (unpatched main vs PR #275):

| Body | Unpatched | Patched | Speedup |
| --- | --- | --- | --- |
| 2 MiB no-`\r` | 88 ms | 6 ms | 14x |
| 8 MiB no-`\r` | 334 ms | 7 ms | 50x |
| 16 MiB no-`\r` | 661 ms | 7.5 ms | 87x |

This should give CodSpeed instrumentation a clear, dominant signal on PR #275.

## Test plan
- [x] `pytest tests/test_benchmarks.py` passes (6 tests)
- [x] `scripts/check` passes
- [ ] CodSpeed run on this PR completes
- [ ] Re-run CodSpeed on PR #275 and verify the speedup is detected

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.