### PR TITLE
Cap multipart boundary length at 256 bytes

### DIFF
--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -148,6 +148,14 @@ DEFAULT_MAX_HEADER_COUNT = 8
 DEFAULT_MAX_HEADER_SIZE = 4096 + 128
 """Default maximum size of a single multipart header line, including syntax overhead."""
 
+MAX_BOUNDARY_LENGTH = 256
+"""Maximum allowed length of a multipart boundary.
+
+[RFC 2046 §5.1.1](https://datatracker.ietf.org/doc/html/rfc2046#section-5.1.1)
+recommends boundaries be at most 70 bytes. 256 bytes is generous headroom over
+every HTTP client.
+"""
+
 
 def parse_options_header(value: str | bytes | None) -> tuple[bytes, dict[bytes, bytes]]:
     """Parses a Content-Type header into a value in the following format: (content_type, {parameters})."""
@@ -1012,6 +1020,8 @@ class MultipartParser(BaseParser):
         # Save our boundary.
         if isinstance(boundary, str):  # pragma: no cover
             boundary = boundary.encode("latin-1")
+        if len(boundary) > MAX_BOUNDARY_LENGTH:
+            raise FormParserError(f"Boundary length {len(boundary)} exceeds maximum of {MAX_BOUNDARY_LENGTH}")
         self.boundary = b"\r\n--" + boundary
 
     def write(self, data: bytes) -> int:

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -78,33 +78,12 @@ FILE_UPLOAD_CHUNKS = split(FILE_UPLOAD)
 WORSTCASE_BCHAR = build_form([build_part(b"file", pattern(b"\r\n", 1024 * 1024), filename=b"file.bin")])
 WORSTCASE_BCHAR_CHUNKS = split(WORSTCASE_BCHAR)
 
-LONG_BOUNDARY = b"-" * 16 + b"x" * (16 * 1024 - 16)
-LONG_BOUNDARY_BODY = (
-    b"--"
-    + LONG_BOUNDARY
-    + b"\r\n"
-    + b'Content-Disposition: form-data; name="file"; filename="file.bin"\r\n'
-    + b"Content-Type: application/octet-stream\r\n\r\n"
-    + pattern(b"abcdefgh", 8 * 1024 * 1024)
-    + b"\r\n--"
-    + LONG_BOUNDARY
-    + b"--\r\n"
-)
-LONG_BOUNDARY_CHUNKS = split(LONG_BOUNDARY_BODY, 16 * 1024)
-
 URLENCODED_LARGE = b"&".join(f"field{i}={'v' * 64}".encode() for i in range(100))
 
 
 @pytest.fixture
 def multipart_parser() -> Iterator[MultipartParser]:
     parser = MultipartParser(BOUNDARY, MULTIPART_CALLBACKS)
-    yield parser
-    parser.finalize()
-
-
-@pytest.fixture
-def long_boundary_parser() -> Iterator[MultipartParser]:
-    parser = MultipartParser(LONG_BOUNDARY, MULTIPART_CALLBACKS)
     yield parser
     parser.finalize()
 
@@ -132,11 +111,6 @@ def test_multipart_file_upload(multipart_parser: MultipartParser) -> None:
 def test_multipart_worstcase_boundary_chars(multipart_parser: MultipartParser) -> None:
     for chunk in WORSTCASE_BCHAR_CHUNKS:
         multipart_parser.write(chunk)
-
-
-def test_multipart_long_boundary(long_boundary_parser: MultipartParser) -> None:
-    for chunk in LONG_BOUNDARY_CHUNKS:
-        long_boundary_parser.write(chunk)
 
 
 def test_querystring_large_form(querystring_parser: QuerystringParser) -> None:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1514,6 +1514,12 @@ class TestFormParser(unittest.TestCase):
         with self.assertRaises(ValueError):
             MultipartParser(b"bound", max_size="foo")  # type: ignore[arg-type]
 
+    def test_boundary_too_long(self) -> None:
+        with self.assertRaisesRegex(FormParserError, "Boundary length 257 exceeds maximum of 256"):
+            MultipartParser(b"x" * 257)
+        # 256 should be accepted.
+        MultipartParser(b"x" * 256)
+
     def test_header_begin_callback(self) -> None:
         """
         This test verifies we call the `on_header_begin` callback.


### PR DESCRIPTION
## Summary
- add a `MAX_BOUNDARY_LENGTH = 256` constant and reject boundaries longer than that in `MultipartParser.__init__`

## Why
[RFC 2046 §5.1.1](https://datatracker.ietf.org/doc/html/rfc2046#section-5.1.1) recommends boundaries be at most 70 bytes. Surveying the boundary-generation code in major HTTP clients shows boundaries cluster between 32 and 71 bytes; nothing in common use comes near 256.

| Client / Library | Boundary length | Composition |
| --- | ---: | --- |
| [reqwest (Rust)](https://github.com/seanmonstar/reqwest/blob/master/src/async_impl/multipart.rs#L745-L753) | 71 | 4 × 16-hex chunks joined by `-` |
| [Go `net/http` `mime/multipart`](https://github.com/golang/go/blob/master/src/mime/multipart/writer.go) | 60 | 30 random bytes, hex-encoded |
| [`form-data` (npm)](https://github.com/form-data/form-data/blob/master/lib/form_data.js#L439-L443) | 50 | 26 dashes + 12 random bytes hex |
| [ureq (Rust)](https://github.com/algesten/ureq/blob/main/src/multipart.rs#L265-L276) | 50 | `----formdata-ureq-` + 16 random bytes hex |
| [curl `--form`](https://github.com/curl/curl/blob/master/lib/mime.c) | 46 | 24 dashes + 22 random alnum |
| [undici fetch FormData (Node)](https://github.com/nodejs/undici/blob/main/lib/web/fetch/body.js) | ~42 | `----formdata-undici-0` + 11 zero-padded digits |
| [formdata-polyfill (node-fetch)](https://github.com/jimmywarting/FormData/blob/master/formdata-to-blob.js) | ~38 | `----formdata-polyfill-` + `Math.random()` |
| [Chromium / Blink](https://chromium.googlesource.com/chromium/src/+/de1a0b79dd71d4691e19eff884553b14ddc56102/third_party/blink/renderer/platform/network/form_data_encoder.cc) | 38 | `----WebKitFormBoundary` + 16 random alnum |
| [urllib3 (used by `requests`)](https://github.com/urllib3/urllib3/blob/main/src/urllib3/filepost.py) | 32 | 16 random bytes, hex |
| [httpx](https://github.com/encode/httpx/blob/master/httpx/_multipart.py) | 32 | `os.urandom(16).hex()` |
| [aiohttp](https://github.com/aio-libs/aiohttp/blob/master/aiohttp/multipart.py) | 32 | `uuid.uuid4().hex` (also rejects >70 itself) |

Capping at 256 bounds the parser's per-chunk look-back region by a constant rather than by attacker-controlled input from the \`Content-Type\` header. The cap accommodates every HTTP client in practice (4x headroom over the longest observed).

## Test plan
- [x] new unit test asserting \`MultipartParser(b"x" * 257)\` raises \`FormParserError\` with the expected message and that 256 is accepted
- [x] full test suite passes (147 tests, 100% coverage)
- [x] dropped the \`test_multipart_long_boundary\` benchmark scenario, which constructed a 16 KiB boundary and is now unreachable

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.