### PR TITLE
Enable the CodSpeed Claude Code plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "codspeed@codspeed-plugin-marketplace": true
+  }
+}


### PR DESCRIPTION
## Summary
- add `.claude/settings.json` with the CodSpeed plugin enabled

## Why
The [CodSpeed Claude Code plugin](https://github.com/CodSpeedHQ/codspeed) ships an MCP server that lets contributors query CodSpeed run data - listing runs, comparing two runs, and pulling flame graphs - directly from Claude Code. Committing this at the project level means contributors who use Claude Code automatically get the plugin enabled when they open the repo, without having to set it up per-clone.

`.claude/settings.local.json` and `.claude/worktrees/` are already gitignored, so this only ships the shared settings file.

## Test plan
- N/A - tooling-only change with no runtime impact

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.