### PR TITLE
Version 0.0.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.28 (2026-05-10)
+
+* Speed up partial-boundary tail scan via `bytes.find` [#281](https://github.com/Kludex/python-multipart/pull/281).
+* Cap multipart boundary length at 256 bytes [#282](https://github.com/Kludex/python-multipart/pull/282).
+
 ## 0.0.27 (2026-04-27)
 
 * Add multipart header limits [#267](https://github.com/Kludex/python-multipart/pull/267).

--- a/python_multipart/__init__.py
+++ b/python_multipart/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.27"
+__version__ = "0.0.28"
 
 from .multipart import (
     BaseParser,


### PR DESCRIPTION
## Summary

- Bump version to 0.0.28.
- Update CHANGELOG with entries for #281 (speed up partial-boundary tail scan) and #282 (cap multipart boundary length at 256 bytes).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.