### PR TITLE
Add 7-day cooldown for dependency resolution via uv exclude-newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ dev = [
     "pymdown-extensions>=10.21.2",
 ]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.uv.pip]
 reinstall-package = ["python-multipart"]
 


### PR DESCRIPTION
## Summary

- Adds `exclude-newer = "7 days"` to a new `[tool.uv]` table in `pyproject.toml`.
- Mirrors a dependabot-style 7-day cooldown: uv skips package versions uploaded within the last 7 days when resolving dependencies, giving freshly released versions time to shake out before they land here.
- uv supports relative durations directly for this setting.

Ref: https://docs.astral.sh/uv/reference/settings/#exclude-newer

## Test plan

- [ ] `uv lock` resolves successfully with the new setting.
- [ ] CI passes.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.