### PR TITLE
Normalize content type when parsing options headers

### DIFF
--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -182,7 +182,7 @@ def parse_options_header(value: str | bytes | None) -> tuple[bytes, dict[bytes, 
     params = message.get_params()
     # If there were no parameters, this would have already returned above
     assert params, "At least the content type value should be present"
-    ctype = params.pop(0)[0].encode("latin-1")
+    ctype = params.pop(0)[0].lower().strip().encode("latin-1")
     options: dict[bytes, bytes] = {}
     for param in params:
         key, value = param

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -273,6 +273,11 @@ class TestParseOptionsHeader(unittest.TestCase):
         self.assertEqual(t, b"application/json")
         self.assertEqual(p, {b"par": b"val", b"asdf": b"foo"})
 
+    def test_content_type_with_parameters_is_normalized(self) -> None:
+        t, p = parse_options_header(b"Multipart/Form-Data; boundary=abc")
+        self.assertEqual(t, b"multipart/form-data")
+        self.assertEqual(p, {b"boundary": b"abc"})
+
     def test_quoted_param(self) -> None:
         t, p = parse_options_header(b'application/json;param="quoted"')
         self.assertEqual(t, b"application/json")
@@ -1554,6 +1559,10 @@ class TestFormParser(unittest.TestCase):
 class TestHelperFunctions(unittest.TestCase):
     def test_create_form_parser(self) -> None:
         r = create_form_parser({"Content-Type": b"application/octet-stream"}, None, None)
+        self.assertTrue(isinstance(r, FormParser))
+
+    def test_create_form_parser_accepts_mixed_case_content_type(self) -> None:
+        r = create_form_parser({"Content-Type": b"Multipart/Form-Data; boundary=abc"}, None, None)
         self.assertTrue(isinstance(r, FormParser))
 
     def test_create_form_parser_error(self) -> None:


### PR DESCRIPTION
## Summary

This normalizes the content type returned by `parse_options_header()` when the header includes parameters.

Previously, content types without parameters were lowercased, but content types with parameters preserved their original casing. That caused a valid header like:

```http
Content-Type: Multipart/Form-Data; boundary=abc
```

to be rejected by `create_form_parser()`, because `FormParser` compares against lowercase media types such as `multipart/form-data`.

Media types are case-insensitive, so this patch lowercases and strips the parsed content type consistently.

## Changes

- Normalize content type returned from `email.message.Message.get_params()`
- Add regression coverage for `parse_options_header()`
- Add regression coverage for `create_form_parser()` with mixed-case multipart content type

## Verification

```bash
uv run pytest tests/test_multipart.py
uv run ruff check python_multipart/multipart.py tests/test_multipart.py
```

Thank you for maintaining this project. Kindly review when you have time, and please let me know if any changes are needed. Happy to update the patch.