### PR TITLE
Version 0.0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.29 (2026-05-17)
+
+* Handle malformed RFC 2231 continuations in `parse_options_header` [#270](https://github.com/Kludex/python-multipart/pull/270).
+
 ## 0.0.28 (2026-05-10)
 
 * Speed up partial-boundary tail scan via `bytes.find` [#281](https://github.com/Kludex/python-multipart/pull/281).

--- a/python_multipart/__init__.py
+++ b/python_multipart/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.28"
+__version__ = "0.0.29"
 
 from .multipart import (
     BaseParser,


### PR DESCRIPTION
## Summary

- Bump version to 0.0.29.
- Update CHANGELOG with entry for #270 (handle malformed RFC 2231 continuations in `parse_options_header`).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.