### PR TITLE
Treat only `&` as the urlencoded field separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Parse `application/x-www-form-urlencoded` bodies per the WHATWG URL standard, treating only `&` as a field separator.
+
 ## 0.0.29 (2026-05-17)
 
 * Handle malformed RFC 2231 continuations in `parse_options_header` [#270](https://github.com/Kludex/python-multipart/pull/270).

--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -126,7 +126,6 @@ COLON = b":"[0]
 SPACE = b" "[0]
 HYPHEN = b"-"[0]
 AMPERSAND = b"&"[0]
-SEMICOLON = b";"[0]
 LOWER_A = b"a"[0]
 LOWER_Z = b"z"[0]
 NULL = b"\x00"[0]
@@ -840,13 +839,13 @@ class QuerystringParser(BaseParser):
                 # yet reached a separator, and thus, if we do, we need to skip
                 # it as it will be the boundary between fields that's supposed
                 # to be there.
-                if ch == AMPERSAND or ch == SEMICOLON:
+                if ch == AMPERSAND:
                     if found_sep:
                         # If we're parsing strictly, we disallow blank chunks.
                         if strict_parsing:
-                            raise QuerystringParseError("Skipping duplicate ampersand/semicolon at %d" % i, offset=i)
+                            raise QuerystringParseError("Skipping duplicate ampersand at %d" % i, offset=i)
                         else:
-                            self.logger.debug("Skipping duplicate ampersand/semicolon at %d", i)
+                            self.logger.debug("Skipping duplicate ampersand at %d", i)
                     else:
                         # This case is when we're skipping the (first)
                         # separator between fields, so we just set our flag
@@ -864,9 +863,7 @@ class QuerystringParser(BaseParser):
             elif state == QuerystringState.FIELD_NAME:
                 # Try and find a separator - we ensure that, if we do, we only
                 # look for the equal sign before it.
-                sep_pos = data.find(b"&", i)
-                if sep_pos == -1:
-                    sep_pos = data.find(b";", i)
+                sep_pos = data.find(b"&", i, length)
 
                 # See if we can find an equals sign in the remaining data.  If
                 # so, we can immediately emit the field name and jump to the
@@ -874,7 +871,7 @@ class QuerystringParser(BaseParser):
                 if sep_pos != -1:
                     equals_pos = data.find(b"=", i, sep_pos)
                 else:
-                    equals_pos = data.find(b"=", i)
+                    equals_pos = data.find(b"=", i, length)
 
                 if equals_pos != -1:
                     # Emit this name.
@@ -921,11 +918,8 @@ class QuerystringParser(BaseParser):
                         i = length
 
             elif state == QuerystringState.FIELD_DATA:
-                # Try finding either an ampersand or a semicolon after this
-                # position.
-                sep_pos = data.find(b"&", i)
-                if sep_pos == -1:
-                    sep_pos = data.find(b";", i)
+                # Try finding an ampersand after this position.
+                sep_pos = data.find(b"&", i, length)
 
                 # If we found it, callback this bit as data and then go back
                 # to expecting to find a field.

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -428,10 +428,10 @@ class TestQuerystringParser(unittest.TestCase):
         self.p.write(b"f=baz")
         self.assert_fields((b"asdf", b"baz"))
 
-    def test_semicolon_separator(self) -> None:
-        self.p.write(b"foo=bar;asdf=baz")
+    def test_semicolon_is_data_not_a_field_separator(self) -> None:
+        self.p.write(b"role=user&x=;role=admin")
 
-        self.assert_fields((b"foo", b"bar"), (b"asdf", b"baz"))
+        self.assert_fields((b"role", b"user"), (b"x", b";role=admin"))
 
     def test_too_large_field(self) -> None:
         self.p.max_size = 15


### PR DESCRIPTION
`QuerystringParser` treated both `&` and `;` as field separators, falling back to a `;` scan whenever no `&` was found. This aligns it with the [WHATWG URL standard](https://url.spec.whatwg.org/#urlencoded-parsing), under which `application/x-www-form-urlencoded` bodies are delimited by `&` only.

`;` is now ordinary field data. This matches every common encoder - `urllib.parse`, browser `URLSearchParams`, httpx, requests, and Rust's `serde_urlencoded`/reqwest all emit `&`-separated bodies and none produce `;`-separated forms - so no conformant client is affected.

Collapsing the two-step `find("&") -> find(";")` lookup into a single `&` search also makes parsing linear in the body length rather than quadratic for `;`-heavy inputs, and the search is now bounded by the truncated `length` so `max_size` is respected within a chunk.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

