### PR TITLE
Bound header field name size before validating

### DIFF
--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -1249,6 +1249,11 @@ class MultipartParser(BaseParser):
                 # validate the whole span at once instead of byte by byte.
                 colon = data.find(b":", i, length)
                 end = colon if colon != -1 else length
+
+                # Enforce the size limit before slicing and validating, so an oversized header
+                # name fails fast instead of copying and scanning a potentially huge span.
+                advance_header_size(end - i if colon == -1 else end - i + 1)
+
                 field = data[i:end]
                 if field.translate(None, TOKEN_CHARS):
                     bad = next(b for b in field if b not in TOKEN_CHARS_SET)
@@ -1260,10 +1265,8 @@ class MultipartParser(BaseParser):
                 index += end - i
                 if colon == -1:
                     # Field name continues into the next chunk.
-                    advance_header_size(end - i)
                     i = length
                 else:
-                    advance_header_size(end - i + 1)
                     # A 0-length header is an error.
                     if index == 0:
                         msg = "Found 0-length header at %d" % (i,)


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #295.

That PR rewrote `HEADER_FIELD` to find the colon and validate the whole field-name span at once. The size check (`advance_header_size`) ran *after* slicing and `translate`-validating the span, so a header field name with no colon arriving in one large `write()` chunk got sliced and scanned in full before the `max_header_size` limit was applied - the limit no longer bounded the work or temporary allocation for an oversized name.

This moves `advance_header_size` to *before* the slice/validate, so an over-limit field name fails fast as it did prior to #295.

For an 8 MiB field-name chunk with the default 4 KiB limit, parser-side temporary allocation drops from ~16 MiB back to ~4 KiB; behaviour for valid input is unchanged.

## Correctness

- All existing tests pass; 100% coverage; mypy + ruff clean.
- Differentially fuzzed against the pre-#295 implementation: identical callback event streams and identical exception classes across randomized bodies x every chunk-split strategy (including byte-by-byte), at small and default header limits.
- Starlette 1.2.1's `tests/test_formparsers.py` (40 tests) pass against this branch.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.