### PR TITLE
Replace per-byte partial-boundary scan with rfind lookbehind

### DIFF
--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -1361,18 +1361,19 @@ class MultipartParser(BaseParser):
                         # We matched the whole boundary string.
                         index = boundary_length - 1
                         i = i0 + boundary_length - 1
+                        c = data[i]
                     else:
-                        # No match found for whole string.
-                        # There may be a partial boundary at the end of the
-                        # data, which the find will not match.
-                        # Since the length to be searched is limited to the
-                        # boundary length, scan the tail for boundary[0] via
-                        # bytes.find (C-level) to keep cost off the Python loop.
-                        i = max(i, length - boundary_length)
-                        j = data.find(boundary[:1], i, length - 1)
-                        i = j if j >= 0 else length - 1
-
-                    c = data[i]
+                        # No whole boundary, but the tail may hold a partial one
+                        # that completes in the next chunk. Boundary starts with
+                        # CR, which an RFC boundary contains nowhere else, so the
+                        # last CR in the tail is the only candidate prefix start.
+                        k = data.rfind(boundary[:1], max(i, length - boundary_length + 1), length)
+                        if k != -1 and boundary.startswith(data[k:length]):
+                            index = length - k
+                        # Carry the partial via index; the end-of-chunk flush
+                        # emits the data before it and re-marks the lookbehind.
+                        i = length
+                        continue
 
                 # Now, we have a couple of cases here.  If our index is before
                 # the end of the boundary...

--- a/tests/test_data/http/crlf_dense_part_data.http
+++ b/tests/test_data/http/crlf_dense_part_data.http
@@ -1,0 +1,34 @@
+--boundary
+Content-Disposition: form-data; name="file"; filename="crlf.bin"
+Content-Type: application/octet-stream
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+--boundar
+
+
+
+
+
+--bound
+
+--boundary--

--- a/tests/test_data/http/crlf_dense_part_data.yaml
+++ b/tests/test_data/http/crlf_dense_part_data.yaml
@@ -1,0 +1,8 @@
+boundary: boundary
+expected:
+  - name: file
+    type: file
+    file_name: crlf.bin
+    content_type: 'application/octet-stream'
+    data: !!binary |
+      DQoNCg0KDQoNCg0KDQoNCg0KDQoNCg0KDQoNCg0KDQoNCg0KDQoNCg0KLS1ib3VuZGFyDQoNCg0KDQoNCg0KLS1ib3VuZA0K

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -779,6 +779,7 @@ single_byte_tests = [
     "almost_match_boundary_without_LF",
     "almost_match_boundary_without_final_hyphen",
     "single_field_single_file",
+    "crlf_dense_part_data",
 ]
 
 EPILOGUE_TEST_HEAD = (


### PR DESCRIPTION
## What

When `find` cannot locate a whole boundary in part data, the tail may hold a partial boundary that completes in the next chunk. The old fallback seeded the per-byte matcher at the tail, which thrashed on CR/LF-dense bodies: `\r\n` matches the boundary prefix, fails at `-`, resets, reconsiders, and re-runs `find` for every `\r\n` pair near the chunk end.

Since `self.boundary` is `\r\n--` + boundary and an RFC boundary cannot contain CR, the last CR in the tail is the only candidate prefix start. We anchor on it with `rfind`, confirm with `startswith`, carry the partial via `index`, and let the existing end-of-chunk flush emit the data and re-mark the lookbehind. This mirrors [multer](https://github.com/rwf2/multer)'s lookbehind strategy.

## Impact

Benchmarked against [`multipart_bench`](https://github.com/defnull/multipart_bench) (1MB part body, 64KB chunks, sansio variant):

| Scenario | before | after |
|---|---|---|
| worstcase_crlf | ~2700 MB/s | **~18500 MB/s** (6.9x) |
| worstcase_lf | ~21500 MB/s | unchanged |
| worstcase_bchar | ~16400 MB/s | unchanged |
| file upload | unchanged | unchanged |

`worstcase_crlf` was the slowest scenario across all pure-Python parsers; it is now the fastest, reaching parity with the LF case.

## Correctness

Verified behaviorally identical to the previous parser across **82k differential comparisons** of the full callback-event stream and error type/offset: every chunk-split strategy (whole, byte-by-byte, fixed-size, random) plus an exhaustive two-chunk sweep with the boundary edge landing on every byte offset. Zero mismatches.

Adds a CRLF-dense corpus case (`crlf_dense_part_data`) to the data-driven test suite, run both whole-write and byte-by-byte. 100% coverage maintained.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.