### PR TITLE
Version 0.0.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.0.32 (2026-06-04)
+
+* Speed up partial-boundary scanning for CR/LF-dense part data [#300](https://github.com/Kludex/python-multipart/pull/300).
+
 ## 0.0.31 (2026-06-04)
 
 * Speed up multipart header parsing and callback dispatch [#295](https://github.com/Kludex/python-multipart/pull/295).

--- a/python_multipart/__init__.py
+++ b/python_multipart/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.31"
+__version__ = "0.0.32"
 
 from .multipart import (
     BaseParser,


### PR DESCRIPTION
Release 0.0.32.

* Speed up partial-boundary scanning for CR/LF-dense part data [#300](https://github.com/Kludex/python-multipart/pull/300).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.