### PR TITLE
fix: initialise _file_base/_ext when file_name is None

### DIFF
--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -409,8 +409,10 @@ class File:
             # Extract just the basename to avoid directory traversal
             basename = os.path.basename(file_name)
             base, ext = os.path.splitext(basename)
-            self._file_base = base
-            self._ext = ext
+        else:
+            base, ext = b"", b""
+        self._file_base = base
+        self._ext = ext
 
     @property
     def field_name(self) -> bytes | None:

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -3,6 +3,32 @@ from pathlib import Path
 from python_multipart.multipart import File
 
 
+def test_none_file_name_with_keep_extensions_no_attribute_error() -> None:
+    """File(file_name=None) must not raise AttributeError when flushed to disk
+    with UPLOAD_KEEP_EXTENSIONS=True (regression: _ext was not initialised for
+    the None branch)."""
+    file = File(None, config={"UPLOAD_KEEP_EXTENSIONS": True, "MAX_MEMORY_FILE_SIZE": 0})
+    try:
+        # Writing one byte exceeds MAX_MEMORY_FILE_SIZE=0, triggering flush_to_disk()
+        # which previously accessed self._ext -> AttributeError.
+        file.write(b"x")
+    finally:
+        file.close()
+
+
+def test_none_file_name_with_keep_filename_no_attribute_error() -> None:
+    """File(file_name=None) must not raise AttributeError when flushed to disk
+    with UPLOAD_KEEP_FILENAME=True (regression: _file_base was not initialised
+    for the None branch)."""
+    file = File(None, config={"UPLOAD_KEEP_FILENAME": True, "MAX_MEMORY_FILE_SIZE": 0})
+    try:
+        # This reaches the UPLOAD_DIR-is-None branch, which accesses self._ext
+        # via the suffix assignment — previously an AttributeError.
+        file.write(b"x")
+    finally:
+        file.close()
+
+
 def test_upload_dir_with_leading_slash_in_filename(tmp_path: Path) -> None:
     upload_dir = tmp_path / "upload"
     upload_dir.mkdir()


### PR DESCRIPTION
## Summary

`File.__init__` only assigned `_file_base` and `_ext` inside the
`if file_name is not None` branch.  When a `File` is created without a
filename (the documented case for `application/octet-stream` uploads,
where `file_name` defaults to `None`), those attributes are never set.
Any call to `_get_disk_file()` that reads them then raises an
`AttributeError`:

- `UPLOAD_KEEP_EXTENSIONS=True` → `self._ext.decode(...)` → `AttributeError: 'File' object has no attribute '_ext'`
- `UPLOAD_KEEP_FILENAME=True` with a dir → `self._file_base + self._ext` → `AttributeError: 'File' object has no attribute '_file_base'`

Both paths are reachable when the memory threshold is exceeded
(`MAX_MEMORY_FILE_SIZE`) during a nameless upload.

## Fix

Move the assignments outside the conditional and supply empty-bytes
defaults for the `None` branch:

```python
if file_name is not None:
    basename = os.path.basename(file_name)
    base, ext = os.path.splitext(basename)
else:
    base, ext = b"", b""
self._file_base = base
self._ext = ext
```

Two regression tests are added to `tests/test_file.py`.

---

This pull request was prepared with the assistance of AI, under my direction and review.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/python-multipart/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

