### PR TITLE
Speed up querystring callback dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Speed up querystring callback dispatch.
+* Speed up querystring callback dispatch [#316](https://github.com/Kludex/python-multipart/pull/316).
 
 ## 0.0.32 (2026-06-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Speed up querystring callback dispatch.
+
 ## 0.0.32 (2026-06-04)
 
 * Speed up partial-boundary scanning for CR/LF-dense part data [#300](https://github.com/Kludex/python-multipart/pull/300).

--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -836,6 +836,7 @@ class QuerystringParser(BaseParser):
         state = self.state
         strict_parsing = self.strict_parsing
         found_sep = self._found_sep
+        callbacks = cast("QuerystringCallbacks", self.callbacks)
 
         i = 0
         while i < length:
@@ -865,7 +866,9 @@ class QuerystringParser(BaseParser):
                     # Emit a field-start event, and go to that state.  Also,
                     # reset the "found_sep" flag, for the next time we get to
                     # this state.
-                    self.callback("field_start")
+                    callback_event = callbacks.get("on_field_start")
+                    if callback_event is not None:
+                        callback_event()
                     i -= 1
                     state = QuerystringState.FIELD_NAME
                     found_sep = False
@@ -885,7 +888,9 @@ class QuerystringParser(BaseParser):
 
                 if equals_pos != -1:
                     # Emit this name.
-                    self.callback("field_name", data, i, equals_pos)
+                    callback_data = callbacks.get("on_field_name")
+                    if callback_data is not None and i != equals_pos:
+                        callback_data(data, i, equals_pos)
 
                     # Jump i to this position.  Note that it will then have 1
                     # added to it below, which means the next iteration of this
@@ -900,15 +905,21 @@ class QuerystringParser(BaseParser):
                         # end - there's no data callback at all (not even with
                         # a blank value).
                         if sep_pos != -1:
-                            self.callback("field_name", data, i, sep_pos)
-                            self.callback("field_end")
+                            callback_data = callbacks.get("on_field_name")
+                            if callback_data is not None and i != sep_pos:
+                                callback_data(data, i, sep_pos)
+                            callback_event = callbacks.get("on_field_end")
+                            if callback_event is not None:
+                                callback_event()
 
                             i = sep_pos - 1
                             state = QuerystringState.BEFORE_FIELD
                         else:
                             # Otherwise, no separator in this block, so the
                             # rest of this chunk must be a name.
-                            self.callback("field_name", data, i, length)
+                            callback_data = callbacks.get("on_field_name")
+                            if callback_data is not None and i != length:
+                                callback_data(data, i, length)
                             i = length
 
                     else:
@@ -924,7 +935,9 @@ class QuerystringParser(BaseParser):
 
                         # No separator in the rest of this chunk, so it's just
                         # a field name.
-                        self.callback("field_name", data, i, length)
+                        callback_data = callbacks.get("on_field_name")
+                        if callback_data is not None and i != length:
+                            callback_data(data, i, length)
                         i = length
 
             elif state == QuerystringState.FIELD_DATA:
@@ -934,8 +947,12 @@ class QuerystringParser(BaseParser):
                 # If we found it, callback this bit as data and then go back
                 # to expecting to find a field.
                 if sep_pos != -1:
-                    self.callback("field_data", data, i, sep_pos)
-                    self.callback("field_end")
+                    callback_data = callbacks.get("on_field_data")
+                    if callback_data is not None and i != sep_pos:
+                        callback_data(data, i, sep_pos)
+                    callback_event = callbacks.get("on_field_end")
+                    if callback_event is not None:
+                        callback_event()
 
                     # Note that we go to the separator, which brings us to the
                     # "before field" state.  This allows us to properly emit
@@ -946,7 +963,9 @@ class QuerystringParser(BaseParser):
 
                 # Otherwise, emit the rest as data and finish.
                 else:
-                    self.callback("field_data", data, i, length)
+                    callback_data = callbacks.get("on_field_data")
+                    if callback_data is not None and i != length:
+                        callback_data(data, i, length)
                     i = length
 
             else:  # pragma: no cover (error case)
@@ -965,10 +984,15 @@ class QuerystringParser(BaseParser):
         if we're still in the middle of a field, an on_field_end callback, and
         then the on_end callback.
         """
+        callbacks = cast("QuerystringCallbacks", self.callbacks)
         # If we're currently in the middle of a field, we finish it.
         if self.state in (QuerystringState.FIELD_DATA, QuerystringState.FIELD_NAME):
-            self.callback("field_end")
-        self.callback("end")
+            callback = callbacks.get("on_field_end")
+            if callback is not None:
+                callback()
+        callback = callbacks.get("on_end")
+        if callback is not None:
+            callback()
 
     def __repr__(self) -> str:
         return "{}(strict_parsing={!r}, max_size={!r})".format(

--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -678,6 +678,10 @@ class BaseParser:
         :param new_func: The new function for the callback.  If None, then the
                          callback will be removed (with no error if it does not
                          exist).
+
+        Updates made while a parser operation is running are not guaranteed to
+        affect later callbacks in that operation. They are guaranteed to apply
+        to the next call to ``write()`` or ``finalize()``.
         """
         if new_func is None:
             self.callbacks.pop("on_" + name, None)  # type: ignore[misc]

--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -678,10 +678,6 @@ class BaseParser:
         :param new_func: The new function for the callback.  If None, then the
                          callback will be removed (with no error if it does not
                          exist).
-
-        Updates made while a parser operation is running are not guaranteed to
-        affect later callbacks in that operation. They are guaranteed to apply
-        to the next call to ``write()`` or ``finalize()``.
         """
         if new_func is None:
             self.callbacks.pop("on_" + name, None)  # type: ignore[misc]

--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -866,9 +866,9 @@ class QuerystringParser(BaseParser):
                     # Emit a field-start event, and go to that state.  Also,
                     # reset the "found_sep" flag, for the next time we get to
                     # this state.
-                    callback_event = callbacks.get("on_field_start")
-                    if callback_event is not None:
-                        callback_event()
+                    on_field_start = callbacks.get("on_field_start")
+                    if on_field_start is not None:
+                        on_field_start()
                     i -= 1
                     state = QuerystringState.FIELD_NAME
                     found_sep = False
@@ -888,9 +888,9 @@ class QuerystringParser(BaseParser):
 
                 if equals_pos != -1:
                     # Emit this name.
-                    callback_data = callbacks.get("on_field_name")
-                    if callback_data is not None and i != equals_pos:
-                        callback_data(data, i, equals_pos)
+                    on_field_name = callbacks.get("on_field_name")
+                    if on_field_name is not None and i != equals_pos:
+                        on_field_name(data, i, equals_pos)
 
                     # Jump i to this position.  Note that it will then have 1
                     # added to it below, which means the next iteration of this
@@ -905,21 +905,21 @@ class QuerystringParser(BaseParser):
                         # end - there's no data callback at all (not even with
                         # a blank value).
                         if sep_pos != -1:
-                            callback_data = callbacks.get("on_field_name")
-                            if callback_data is not None and i != sep_pos:
-                                callback_data(data, i, sep_pos)
-                            callback_event = callbacks.get("on_field_end")
-                            if callback_event is not None:
-                                callback_event()
+                            on_field_name = callbacks.get("on_field_name")
+                            if on_field_name is not None and i != sep_pos:
+                                on_field_name(data, i, sep_pos)
+                            on_field_end = callbacks.get("on_field_end")
+                            if on_field_end is not None:
+                                on_field_end()
 
                             i = sep_pos - 1
                             state = QuerystringState.BEFORE_FIELD
                         else:
                             # Otherwise, no separator in this block, so the
                             # rest of this chunk must be a name.
-                            callback_data = callbacks.get("on_field_name")
-                            if callback_data is not None and i != length:
-                                callback_data(data, i, length)
+                            on_field_name = callbacks.get("on_field_name")
+                            if on_field_name is not None and i != length:
+                                on_field_name(data, i, length)
                             i = length
 
                     else:
@@ -935,9 +935,9 @@ class QuerystringParser(BaseParser):
 
                         # No separator in the rest of this chunk, so it's just
                         # a field name.
-                        callback_data = callbacks.get("on_field_name")
-                        if callback_data is not None and i != length:
-                            callback_data(data, i, length)
+                        on_field_name = callbacks.get("on_field_name")
+                        if on_field_name is not None and i != length:
+                            on_field_name(data, i, length)
                         i = length
 
             elif state == QuerystringState.FIELD_DATA:
@@ -947,12 +947,12 @@ class QuerystringParser(BaseParser):
                 # If we found it, callback this bit as data and then go back
                 # to expecting to find a field.
                 if sep_pos != -1:
-                    callback_data = callbacks.get("on_field_data")
-                    if callback_data is not None and i != sep_pos:
-                        callback_data(data, i, sep_pos)
-                    callback_event = callbacks.get("on_field_end")
-                    if callback_event is not None:
-                        callback_event()
+                    on_field_data = callbacks.get("on_field_data")
+                    if on_field_data is not None and i != sep_pos:
+                        on_field_data(data, i, sep_pos)
+                    on_field_end = callbacks.get("on_field_end")
+                    if on_field_end is not None:
+                        on_field_end()
 
                     # Note that we go to the separator, which brings us to the
                     # "before field" state.  This allows us to properly emit
@@ -963,9 +963,9 @@ class QuerystringParser(BaseParser):
 
                 # Otherwise, emit the rest as data and finish.
                 else:
-                    callback_data = callbacks.get("on_field_data")
-                    if callback_data is not None and i != length:
-                        callback_data(data, i, length)
+                    on_field_data = callbacks.get("on_field_data")
+                    if on_field_data is not None and i != length:
+                        on_field_data(data, i, length)
                     i = length
 
             else:  # pragma: no cover (error case)
@@ -987,12 +987,12 @@ class QuerystringParser(BaseParser):
         callbacks = cast("QuerystringCallbacks", self.callbacks)
         # If we're currently in the middle of a field, we finish it.
         if self.state in (QuerystringState.FIELD_DATA, QuerystringState.FIELD_NAME):
-            callback = callbacks.get("on_field_end")
-            if callback is not None:
-                callback()
-        callback = callbacks.get("on_end")
-        if callback is not None:
-            callback()
+            on_field_end = callbacks.get("on_field_end")
+            if on_field_end is not None:
+                on_field_end()
+        on_end = callbacks.get("on_end")
+        if on_end is not None:
+            on_end()
 
     def __repr__(self) -> str:
         return "{}(strict_parsing={!r}, max_size={!r})".format(

--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -78,6 +78,14 @@ if TYPE_CHECKING:
 _missing = object()
 
 
+def _noop_event() -> None:
+    pass
+
+
+def _noop_data(_data: bytes, _start: int, _end: int) -> None:
+    pass
+
+
 class QuerystringState(IntEnum):
     """Querystring parser states.
 
@@ -866,9 +874,8 @@ class QuerystringParser(BaseParser):
                     # Emit a field-start event, and go to that state.  Also,
                     # reset the "found_sep" flag, for the next time we get to
                     # this state.
-                    on_field_start = callbacks.get("on_field_start")
-                    if on_field_start is not None:
-                        on_field_start()
+                    on_field_start = callbacks.get("on_field_start", _noop_event)
+                    on_field_start()
                     i -= 1
                     state = QuerystringState.FIELD_NAME
                     found_sep = False
@@ -888,8 +895,8 @@ class QuerystringParser(BaseParser):
 
                 if equals_pos != -1:
                     # Emit this name.
-                    on_field_name = callbacks.get("on_field_name")
-                    if on_field_name is not None and i != equals_pos:
+                    on_field_name = callbacks.get("on_field_name", _noop_data)
+                    if i != equals_pos:
                         on_field_name(data, i, equals_pos)
 
                     # Jump i to this position.  Note that it will then have 1
@@ -905,20 +912,19 @@ class QuerystringParser(BaseParser):
                         # end - there's no data callback at all (not even with
                         # a blank value).
                         if sep_pos != -1:
-                            on_field_name = callbacks.get("on_field_name")
-                            if on_field_name is not None and i != sep_pos:
+                            on_field_name = callbacks.get("on_field_name", _noop_data)
+                            if i != sep_pos:
                                 on_field_name(data, i, sep_pos)
-                            on_field_end = callbacks.get("on_field_end")
-                            if on_field_end is not None:
-                                on_field_end()
+                            on_field_end = callbacks.get("on_field_end", _noop_event)
+                            on_field_end()
 
                             i = sep_pos - 1
                             state = QuerystringState.BEFORE_FIELD
                         else:
                             # Otherwise, no separator in this block, so the
                             # rest of this chunk must be a name.
-                            on_field_name = callbacks.get("on_field_name")
-                            if on_field_name is not None and i != length:
+                            on_field_name = callbacks.get("on_field_name", _noop_data)
+                            if i != length:
                                 on_field_name(data, i, length)
                             i = length
 
@@ -935,8 +941,8 @@ class QuerystringParser(BaseParser):
 
                         # No separator in the rest of this chunk, so it's just
                         # a field name.
-                        on_field_name = callbacks.get("on_field_name")
-                        if on_field_name is not None and i != length:
+                        on_field_name = callbacks.get("on_field_name", _noop_data)
+                        if i != length:
                             on_field_name(data, i, length)
                         i = length
 
@@ -947,12 +953,11 @@ class QuerystringParser(BaseParser):
                 # If we found it, callback this bit as data and then go back
                 # to expecting to find a field.
                 if sep_pos != -1:
-                    on_field_data = callbacks.get("on_field_data")
-                    if on_field_data is not None and i != sep_pos:
+                    on_field_data = callbacks.get("on_field_data", _noop_data)
+                    if i != sep_pos:
                         on_field_data(data, i, sep_pos)
-                    on_field_end = callbacks.get("on_field_end")
-                    if on_field_end is not None:
-                        on_field_end()
+                    on_field_end = callbacks.get("on_field_end", _noop_event)
+                    on_field_end()
 
                     # Note that we go to the separator, which brings us to the
                     # "before field" state.  This allows us to properly emit
@@ -963,8 +968,8 @@ class QuerystringParser(BaseParser):
 
                 # Otherwise, emit the rest as data and finish.
                 else:
-                    on_field_data = callbacks.get("on_field_data")
-                    if on_field_data is not None and i != length:
+                    on_field_data = callbacks.get("on_field_data", _noop_data)
+                    if i != length:
                         on_field_data(data, i, length)
                     i = length
 
@@ -987,12 +992,10 @@ class QuerystringParser(BaseParser):
         callbacks = cast("QuerystringCallbacks", self.callbacks)
         # If we're currently in the middle of a field, we finish it.
         if self.state in (QuerystringState.FIELD_DATA, QuerystringState.FIELD_NAME):
-            on_field_end = callbacks.get("on_field_end")
-            if on_field_end is not None:
-                on_field_end()
-        on_end = callbacks.get("on_end")
-        if on_end is not None:
-            on_end()
+            on_field_end = callbacks.get("on_field_end", _noop_event)
+            on_field_end()
+        on_end = callbacks.get("on_end", _noop_event)
+        on_end()
 
     def __repr__(self) -> str:
         return "{}(strict_parsing={!r}, max_size={!r})".format(

--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -845,6 +845,18 @@ class QuerystringParser(BaseParser):
         strict_parsing = self.strict_parsing
         found_sep = self._found_sep
         callbacks = cast("QuerystringCallbacks", self.callbacks)
+        on_field_start = callbacks.get("on_field_start")
+        on_field_name = callbacks.get("on_field_name")
+        on_field_data = callbacks.get("on_field_data")
+        on_field_end = callbacks.get("on_field_end")
+        if on_field_start is None:
+            on_field_start = _noop_event
+        if on_field_name is None:
+            on_field_name = _noop_data
+        if on_field_data is None:
+            on_field_data = _noop_data
+        if on_field_end is None:
+            on_field_end = _noop_event
 
         i = 0
         while i < length:
@@ -874,7 +886,6 @@ class QuerystringParser(BaseParser):
                     # Emit a field-start event, and go to that state.  Also,
                     # reset the "found_sep" flag, for the next time we get to
                     # this state.
-                    on_field_start = callbacks.get("on_field_start", _noop_event)
                     on_field_start()
                     i -= 1
                     state = QuerystringState.FIELD_NAME
@@ -895,7 +906,6 @@ class QuerystringParser(BaseParser):
 
                 if equals_pos != -1:
                     # Emit this name.
-                    on_field_name = callbacks.get("on_field_name", _noop_data)
                     if i != equals_pos:
                         on_field_name(data, i, equals_pos)
 
@@ -912,10 +922,8 @@ class QuerystringParser(BaseParser):
                         # end - there's no data callback at all (not even with
                         # a blank value).
                         if sep_pos != -1:
-                            on_field_name = callbacks.get("on_field_name", _noop_data)
                             if i != sep_pos:
                                 on_field_name(data, i, sep_pos)
-                            on_field_end = callbacks.get("on_field_end", _noop_event)
                             on_field_end()
 
                             i = sep_pos - 1
@@ -923,7 +931,6 @@ class QuerystringParser(BaseParser):
                         else:
                             # Otherwise, no separator in this block, so the
                             # rest of this chunk must be a name.
-                            on_field_name = callbacks.get("on_field_name", _noop_data)
                             if i != length:
                                 on_field_name(data, i, length)
                             i = length
@@ -941,7 +948,6 @@ class QuerystringParser(BaseParser):
 
                         # No separator in the rest of this chunk, so it's just
                         # a field name.
-                        on_field_name = callbacks.get("on_field_name", _noop_data)
                         if i != length:
                             on_field_name(data, i, length)
                         i = length
@@ -953,10 +959,8 @@ class QuerystringParser(BaseParser):
                 # If we found it, callback this bit as data and then go back
                 # to expecting to find a field.
                 if sep_pos != -1:
-                    on_field_data = callbacks.get("on_field_data", _noop_data)
                     if i != sep_pos:
                         on_field_data(data, i, sep_pos)
-                    on_field_end = callbacks.get("on_field_end", _noop_event)
                     on_field_end()
 
                     # Note that we go to the separator, which brings us to the
@@ -968,7 +972,6 @@ class QuerystringParser(BaseParser):
 
                 # Otherwise, emit the rest as data and finish.
                 else:
-                    on_field_data = callbacks.get("on_field_data", _noop_data)
                     if i != length:
                         on_field_data(data, i, length)
                     i = length
@@ -992,9 +995,13 @@ class QuerystringParser(BaseParser):
         callbacks = cast("QuerystringCallbacks", self.callbacks)
         # If we're currently in the middle of a field, we finish it.
         if self.state in (QuerystringState.FIELD_DATA, QuerystringState.FIELD_NAME):
-            on_field_end = callbacks.get("on_field_end", _noop_event)
+            on_field_end = callbacks.get("on_field_end")
+            if on_field_end is None:
+                on_field_end = _noop_event
             on_field_end()
-        on_end = callbacks.get("on_end", _noop_event)
+        on_end = callbacks.get("on_end")
+        if on_end is None:
+            on_end = _noop_event
         on_end()
 
     def __repr__(self) -> str:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -429,6 +429,19 @@ class TestQuerystringParser(unittest.TestCase):
         self.assertEqual(parser.write(b"foo=bar"), 7)
         parser.finalize()
 
+    def test_none_callbacks(self) -> None:
+        callbacks: Any = {
+            "on_field_start": None,
+            "on_field_name": None,
+            "on_field_data": None,
+            "on_field_end": None,
+            "on_end": None,
+        }
+        parser = QuerystringParser(callbacks)
+
+        self.assertEqual(parser.write(b"foo=bar"), 7)
+        parser.finalize()
+
     def test_querystring_blank_beginning(self) -> None:
         self.p.write(b"&foo=bar")
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -365,6 +365,10 @@ class TestBaseParser(unittest.TestCase):
             nonlocal called
             called += 1
 
+        def on_data(data: bytes, start: int, end: int) -> None:
+            nonlocal called
+            called += 1
+
         self.b.set_callback("foo", on_foo)  # type: ignore[arg-type]
         self.b.callback("foo")  # type: ignore[arg-type]
         self.assertEqual(called, 1)
@@ -372,6 +376,12 @@ class TestBaseParser(unittest.TestCase):
         self.b.set_callback("foo", None)  # type: ignore[arg-type]
         self.b.callback("foo")  # type: ignore[arg-type]
         self.assertEqual(called, 1)
+
+        self.b.set_callback("data", on_data)
+        self.b.callback("data", b"", 0, 0)
+        self.assertEqual(called, 1)
+        self.b.callback("data", b"x", 0, 1)
+        self.assertEqual(called, 2)
 
 
 class TestQuerystringParser(unittest.TestCase):
@@ -412,6 +422,23 @@ class TestQuerystringParser(unittest.TestCase):
         self.p.write(b"foo=bar")
 
         self.assert_fields((b"foo", b"bar"))
+
+    def test_set_callback_during_write(self) -> None:
+        names: list[bytes] = []
+
+        def on_field_start() -> None:
+            parser.set_callback("field_name", on_replacement_field_name)
+
+        def on_initial_field_name(data: bytes, start: int, end: int) -> None:
+            raise AssertionError("The replaced callback was called")
+
+        def on_replacement_field_name(data: bytes, start: int, end: int) -> None:
+            names.append(data[start:end])
+
+        parser = QuerystringParser(callbacks={"on_field_start": on_field_start, "on_field_name": on_initial_field_name})
+        parser.write(b"foo=bar")
+
+        self.assertEqual(names, [b"foo"])
 
     def test_querystring_blank_beginning(self) -> None:
         self.p.write(b"&foo=bar")

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -423,22 +423,11 @@ class TestQuerystringParser(unittest.TestCase):
 
         self.assert_fields((b"foo", b"bar"))
 
-    def test_set_callback_during_write(self) -> None:
-        names: list[bytes] = []
+    def test_no_callbacks(self) -> None:
+        parser = QuerystringParser()
 
-        def on_field_start() -> None:
-            parser.set_callback("field_name", on_replacement_field_name)
-
-        def on_initial_field_name(data: bytes, start: int, end: int) -> None:
-            raise AssertionError("The replaced callback was called")
-
-        def on_replacement_field_name(data: bytes, start: int, end: int) -> None:
-            names.append(data[start:end])
-
-        parser = QuerystringParser(callbacks={"on_field_start": on_field_start, "on_field_name": on_initial_field_name})
-        parser.write(b"foo=bar")
-
-        self.assertEqual(names, [b"foo"])
+        self.assertEqual(parser.write(b"foo=bar"), 7)
+        parser.finalize()
 
     def test_querystring_blank_beginning(self) -> None:
         self.p.write(b"&foo=bar")


### PR DESCRIPTION
## Summary

- resolve `QuerystringParser` callbacks through fixed callback keys once per input chunk instead of using `BaseParser.callback()` for every event
- use shared no-op defaults to eliminate repeated optional-callback checks
- avoid callback-name construction and an extra Python method call on each parsed field event
- preserve zero-length data suppression and support omitted callbacks through shared no-op functions

## Performance

The latest CodSpeed simulation reports a **70.17% efficiency improvement** for `test_querystring_large_form`, from 912.9 µs to 536.5 µs. A same-environment local wall-time benchmark on Python 3.13 improved from approximately 80 µs to 49 µs (about 39%). The other four CodSpeed benchmarks are unchanged.

## Validation

- 160 tests pass
- 100% statement coverage
- Ruff passes
- mypy passes
- source distribution check passes


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/python-multipart/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->