### PR TITLE
Create a fresh parser per benchmark iteration

### DIFF
--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -88,33 +88,33 @@ def make_querystring_parser() -> QuerystringParser:
     return QuerystringParser(QUERYSTRING_CALLBACKS)
 
 
-def test_multipart_simple_form() -> None:
+def test_parse_multipart_simple_form() -> None:
     parser = make_multipart_parser()
     parser.write(SIMPLE_FORM)
     parser.finalize()
 
 
-def test_multipart_large_form() -> None:
+def test_parse_multipart_large_form() -> None:
     parser = make_multipart_parser()
     parser.write(LARGE_FORM)
     parser.finalize()
 
 
-def test_multipart_file_upload() -> None:
+def test_parse_multipart_file_upload() -> None:
     parser = make_multipart_parser()
     for chunk in FILE_UPLOAD_CHUNKS:
         parser.write(chunk)
     parser.finalize()
 
 
-def test_multipart_worstcase_boundary_chars() -> None:
+def test_parse_multipart_worstcase_boundary_chars() -> None:
     parser = make_multipart_parser()
     for chunk in WORSTCASE_BCHAR_CHUNKS:
         parser.write(chunk)
     parser.finalize()
 
 
-def test_querystring_large_form() -> None:
+def test_parse_querystring_large_form() -> None:
     parser = make_querystring_parser()
     parser.write(URLENCODED_LARGE)
     parser.finalize()

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import string
-from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import pytest
@@ -81,37 +80,41 @@ WORSTCASE_BCHAR_CHUNKS = split(WORSTCASE_BCHAR)
 URLENCODED_LARGE = b"&".join(f"field{i}={'v' * 64}".encode() for i in range(100))
 
 
-@pytest.fixture
-def multipart_parser() -> Iterator[MultipartParser]:
-    parser = MultipartParser(BOUNDARY, MULTIPART_CALLBACKS)
-    yield parser
+def make_multipart_parser() -> MultipartParser:
+    return MultipartParser(BOUNDARY, MULTIPART_CALLBACKS)
+
+
+def make_querystring_parser() -> QuerystringParser:
+    return QuerystringParser(QUERYSTRING_CALLBACKS)
+
+
+def test_multipart_simple_form() -> None:
+    parser = make_multipart_parser()
+    parser.write(SIMPLE_FORM)
     parser.finalize()
 
 
-@pytest.fixture
-def querystring_parser() -> Iterator[QuerystringParser]:
-    parser = QuerystringParser(QUERYSTRING_CALLBACKS)
-    yield parser
+def test_multipart_large_form() -> None:
+    parser = make_multipart_parser()
+    parser.write(LARGE_FORM)
     parser.finalize()
 
 
-def test_multipart_simple_form(multipart_parser: MultipartParser) -> None:
-    multipart_parser.write(SIMPLE_FORM)
-
-
-def test_multipart_large_form(multipart_parser: MultipartParser) -> None:
-    multipart_parser.write(LARGE_FORM)
-
-
-def test_multipart_file_upload(multipart_parser: MultipartParser) -> None:
+def test_multipart_file_upload() -> None:
+    parser = make_multipart_parser()
     for chunk in FILE_UPLOAD_CHUNKS:
-        multipart_parser.write(chunk)
+        parser.write(chunk)
+    parser.finalize()
 
 
-def test_multipart_worstcase_boundary_chars(multipart_parser: MultipartParser) -> None:
+def test_multipart_worstcase_boundary_chars() -> None:
+    parser = make_multipart_parser()
     for chunk in WORSTCASE_BCHAR_CHUNKS:
-        multipart_parser.write(chunk)
+        parser.write(chunk)
+    parser.finalize()
 
 
-def test_querystring_large_form(querystring_parser: QuerystringParser) -> None:
-    querystring_parser.write(URLENCODED_LARGE)
+def test_querystring_large_form() -> None:
+    parser = make_querystring_parser()
+    parser.write(URLENCODED_LARGE)
+    parser.finalize()


### PR DESCRIPTION
## Summary

- replace parser fixtures with explicit parser factory helpers
- create and finalize a fresh parser inside every measured benchmark invocation
- ensure repeated CodSpeed iterations parse the complete input instead of writing to an already-finished parser

## Why

CodSpeed invokes each benchmark function repeatedly while retaining its pytest fixtures. The multipart fixture previously yielded one parser for the entire benchmark run. After the first invocation that parser was in `MultipartState.END`, so later iterations only discarded input.

The querystring fixture had a similar lifecycle problem: repeated invocations continued from the previous parser state, and `finalize()` ran only once after all measured iterations.

The broken lifecycle was visible locally because the simple and 100-field multipart benchmarks had nearly identical simulated costs. With a fresh parser per invocation, the 100-field benchmark performs far fewer iterations and correctly measures the complete parse.

## CodSpeed report

CodSpeed now reports five new benchmarks and no performance regression, establishing the corrected baseline successfully. The five old benchmark identifiers are skipped because their ended-parser measurements are intentionally replaced.

This PR deliberately changes the measured workload. The base branch parses the multipart input only on the first benchmark iteration; subsequent iterations write to a parser already in `MultipartState.END` and discard the input. The head branch parses the complete request on every iteration.

The benchmark functions are renamed from `test_multipart_*` to `test_parse_multipart_*` (and likewise for querystrings) because these are new benchmark semantics, not comparable performance measurements. This establishes a clean CodSpeed baseline for complete request parses and prevents the ended-parser measurements from being reported as package regressions.

## Validation

- 160 tests pass
- 100% statement coverage
- Ruff passes
- mypy passes
- all five CodSpeed benchmarks run successfully with a fresh parser per invocation


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/python-multipart/pull/318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

