### PR TITLE
Close incomplete multipart upload files

### DIFF
--- a/python_multipart/multipart.py
+++ b/python_multipart/multipart.py
@@ -1614,6 +1614,7 @@ class FormParser:
         self.boundary = boundary
         self.bytes_received = 0
         self.parser = None
+        self._close_files: Callable[[], None] | None = None
 
         # Save callbacks.
         self.on_field = on_field
@@ -1647,11 +1648,21 @@ class FormParser:
 
                 # Call our callback.
                 if on_file:
-                    on_file(file)
+                    completed_file = file
+                    file = None
+                    on_file(completed_file)
 
                 # Call the on-end callback.
                 if self.on_end is not None:
                     self.on_end()
+
+            def close_current_file() -> None:
+                nonlocal file
+                if file is not None:
+                    file.close()
+                    file = None
+
+            self._close_files = close_current_file
 
             # Instantiate an octet-stream parser
             parser = OctetStreamParser(
@@ -1720,6 +1731,7 @@ class FormParser:
             f_multi: File | Field | None = None
             writer: File | Field | Base64Decoder | QuotedPrintableDecoder | None = None
             is_file = False
+            files: list[File] = []
 
             def on_part_begin() -> None:
                 # Reset headers in case this isn't the first part.
@@ -1739,6 +1751,7 @@ class FormParser:
                 if is_file:
                     if on_file:
                         assert isinstance(f_multi, File)
+                        files.remove(f_multi)
                         on_file(f_multi)
                 else:
                     if on_field:
@@ -1780,6 +1793,7 @@ class FormParser:
                 else:
                     f_multi = File(file_name, field_name, config=self.config, content_type=content_type)
                     is_file = True
+                    files.append(f_multi)
 
                 # Parse the given Content-Transfer-Encoding to determine what
                 # we need to do with the incoming data.
@@ -1812,6 +1826,12 @@ class FormParser:
                     writer.finalize()
                 if self.on_end is not None:
                     self.on_end()
+
+            def close_files() -> None:
+                while files:
+                    files.pop().close()
+
+            self._close_files = close_files
 
             # Instantiate a multipart parser.
             parser = MultipartParser(
@@ -1859,8 +1879,12 @@ class FormParser:
 
     def close(self) -> None:
         """Close the parser."""
-        if self.parser is not None and hasattr(self.parser, "close"):
-            self.parser.close()
+        try:
+            if self.parser is not None and hasattr(self.parser, "close"):
+                self.parser.close()
+        finally:
+            if self._close_files is not None:
+                self._close_files()
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(content_type={self.content_type!r}, parser={self.parser!r})"

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 from io import BytesIO
 from typing import TYPE_CHECKING
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import yaml
@@ -1009,12 +1009,44 @@ class TestFormParser(unittest.TestCase):
             uploaded_file = self.files[0]
             assert uploaded_file.actual_file_name is not None
             actual_file_name = uploaded_file.actual_file_name.decode(sys.getfilesystemencoding())
+            self.f.close()
+
+            self.assertFalse(uploaded_file.file_object.closed)
             uploaded_file.close()
 
             try:
                 self.assertTrue(os.path.exists(actual_file_name))
             finally:
                 os.unlink(actual_file_name)
+
+    def test_close_closes_incomplete_upload(self) -> None:
+        for transfer_encoding, data in ((b"binary", b"test"), (b"base64", b"dGVzdA=="), (b"quoted-printable", b"test")):
+            with (
+                self.subTest(transfer_encoding=transfer_encoding),
+                tempfile.TemporaryDirectory() as upload_dir,
+                patch.object(File, "close", autospec=True, side_effect=File.close) as close,
+            ):
+                self.make(
+                    "boundary", config={"UPLOAD_DIR": upload_dir, "UPLOAD_DELETE_TMP": False, "MAX_MEMORY_FILE_SIZE": 1}
+                )
+                body = (
+                    b"--boundary\r\n"
+                    b'Content-Disposition: form-data; name="file"; filename="test.txt"\r\n'
+                    b"Content-Type: text/plain\r\n"
+                    b"Content-Transfer-Encoding: " + transfer_encoding + b"\r\n\r\n" + data
+                )
+
+                self.f.write(body)
+                paths = os.listdir(upload_dir)
+                self.assertEqual(len(paths), 1)
+
+                self.f.close()
+                self.f.close()
+
+                close.assert_called_once()
+                self.assertTrue(close.call_args.args[0].file_object.closed)
+                self.assertEqual(os.listdir(upload_dir), paths)
+                self.assertEqual(self.files, [])
 
     @parametrize("param", [t for t in http_tests if t["name"] in single_byte_tests])
     def test_feed_single_bytes(self, param: TestParams) -> None:
@@ -1294,6 +1326,33 @@ class TestFormParser(unittest.TestCase):
         self.assert_file_data(files[0], b"test1234")
         self.assertTrue(on_end.called)
 
+        f.close()
+        self.assertFalse(files[0].file_object.closed)
+        files[0].close()
+
+    def test_close_closes_incomplete_octet_stream_upload(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as upload_dir,
+            patch.object(File, "close", autospec=True, side_effect=File.close) as close,
+        ):
+            f = FormParser(
+                "application/octet-stream",
+                None,
+                None,
+                file_name=b"test.txt",
+                config={"UPLOAD_DIR": upload_dir, "UPLOAD_DELETE_TMP": False, "MAX_MEMORY_FILE_SIZE": 1},
+            )
+            f.write(b"test")
+            paths = os.listdir(upload_dir)
+            self.assertEqual(len(paths), 1)
+
+            f.close()
+            f.close()
+
+            close.assert_called_once()
+            self.assertTrue(close.call_args.args[0].file_object.closed)
+            self.assertEqual(os.listdir(upload_dir), paths)
+
     def test_querystring(self) -> None:
         fields: list[Field] = []
 
@@ -1389,6 +1448,34 @@ class TestFormParser(unittest.TestCase):
         f.write(data)
         f.finalize()
         self.assert_file_data(files[0], b"Test")
+
+    def test_bad_content_transfer_encoding_closes_current_file(self) -> None:
+        data = (
+            b"--boundary\r\n"
+            b'Content-Disposition: form-data; name="first"; filename="first.txt"\r\n\r\n'
+            b"first\r\n"
+            b"--boundary\r\n"
+            b'Content-Disposition: form-data; name="second"; filename="second.txt"\r\n'
+            b"Content-Transfer-Encoding: badstuff\r\n\r\n"
+        )
+        files: list[File] = []
+        f = FormParser(
+            "multipart/form-data", None, files.append, boundary="boundary", config={"UPLOAD_ERROR_ON_BAD_CTE": True}
+        )
+
+        with patch.object(File, "close", autospec=True, side_effect=File.close) as close:
+            with self.assertRaises(FormParserError):
+                f.write(data)
+
+            self.assertEqual(len(files), 1)
+            f.close()
+
+            close.assert_called_once()
+            self.assertIsNot(close.call_args.args[0], files[0])
+            self.assertTrue(close.call_args.args[0].file_object.closed)
+            self.assertFalse(files[0].file_object.closed)
+
+        files[0].close()
 
     def test_bad_content_disposition(self) -> None:
         # Field name is required per RFC 7578 §4.2.


### PR DESCRIPTION
## Problem

When a multipart request ends before the current file part is completed,
`FormParser.close()` closes only the low-level parser. The active `File` or
decoder-backed writer remains open even though it was never delivered to the
application through `on_file`.

Completed files are different: once passed to `on_file`, their lifetime belongs
to the application and closing the parser must not close them.

## Solution

Track whether the active multipart file has been transferred to `on_file`. On
`FormParser.close()`, close an active writer only when it is still owned by the
parser. Clear the writer after closing it so repeated calls to `close()` are
safe.

This closes both direct file writers and decoder-backed writers. It preserves
the configured `UPLOAD_DELETE_TMP=False` behavior: closing an unfinished file
releases its file descriptor but does not unlink the retained temporary file.

## Tests

- Verify incomplete binary, Base64, and quoted-printable uploads are closed
  exactly once.
- Verify repeated `FormParser.close()` calls are safe.
- Verify completed files delivered to `on_file` remain open and caller-owned.
- Verify `UPLOAD_DELETE_TMP=False` continues to retain the file after closing.

Verification performed:

```text
163 passed, 3 subtests passed
TOTAL 885 statements, 0 missing, 100% coverage
Ruff: passed
mypy: passed
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/python-multipart/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

